### PR TITLE
Protect from peers without supported transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ sw.addStreamMuxer(streamMuxer, [options])
 ### Dial to another peer
 
 ```JavaScript
-sw.dial(PeerInfo, options, protocol)
-sw.dial(PeerInfo, options) 
+sw.dial(PeerInfo, options, protocol, callback)
+sw.dial(PeerInfo, options, callback)
 ```
 
 dial uses the best transport (whatever works first, in the future we can have some criteria), and jump starts the connection until the point we have to negotiate the protocol. If a muxer is available, then drop the muxer onto that connection. Good to warm up connections or to check for connectivity. If we have already a muxer for that peerInfo, than do nothing.

--- a/src/swarm.js
+++ b/src/swarm.js
@@ -126,6 +126,11 @@ function Swarm (peerInfo) {
       })
     })
 
+    if (!multiaddrs.length) {
+      callback(new Error("The swarm doesn't support any of the peer transports"))
+      return
+    }
+
     var conn
 
     async.eachSeries(multiaddrs, function (multiaddr, next) {
@@ -175,6 +180,7 @@ function Swarm (peerInfo) {
       // if protocol is selected, multistream that protocol
       if (!conn) {
         callback(new Error('Unable to open a connection'))
+        return
       }
 
       if (self.muxers['spdy']) {

--- a/tests/swarm-test.js
+++ b/tests/swarm-test.js
@@ -13,15 +13,33 @@ var Swarm = require('../src')
 var tcp = require('libp2p-tcp')
 var Spdy = require('libp2p-spdy')
 
-/* TODO
-experiment('Basics', function () {
-  test('enforces creation with new', function (done) {done() })
-})
-*/
-
 // because of Travis-CI
 process.on('uncaughtException', function (err) {
   console.log('Caught exception: ' + err)
+})
+
+experiment('Basics', function () {
+  test('enforces creation with new', function (done) {
+    expect(function () {
+      Swarm()
+    }).to.throw()
+    done()
+  })
+})
+
+experiment('When dialing', function () {
+  experiment('if the swarm does add any of the peer transports', function () {
+    test('it returns an error', function (done) {
+      var peerOne = new Peer(Id.create(), [multiaddr('/ip4/127.0.0.1/tcp/8090')])
+      var peerTwo = new Peer(Id.create(), [multiaddr('/ip4/127.0.0.1/tcp/8091')])
+      var swarm = new Swarm(peerOne)
+
+      swarm.dial(peerTwo, {}, function (err) {
+        expect(err).to.exist()
+        done()
+      })
+    })
+  })
 })
 
 experiment('Without a Stream Muxer', function () {


### PR DESCRIPTION
# What

Trying to run compliance tests from the kad router module. I've tried to port the new swarm API but forgot to add a transport. The tests ended up blowing up instead of failing gracefully.
# How to test

``` js
peerOne = new Peer(Id.create(), [multiaddr('/ip4/127.0.0.1/tcp/8090')])
peerTwo = new Peer(Id.create(), [multiaddr('/ip4/127.0.0.1/tcp/8091')])
swarm = new Swarm(peerOne)
swarm.dial(peerTwo, {}, function (err) {
  console.log(err);
});
```

This just work and display the error.
