### PR TITLE
Do not force a callback in addTransport

### DIFF
--- a/src/swarm.js
+++ b/src/swarm.js
@@ -63,7 +63,9 @@ function Swarm (peerInfo) {
         self.peerInfo.multiaddrs.push(options.multiaddr)
       }
 
-      callback()
+      if (callback) {
+        callback()
+      }
     })
   }
 


### PR DESCRIPTION
# What

Make callback optional
# How to test

``` js
swarmZero.addTransport('tcp', tcp, { multiaddr: mh }, {}, {port: 8090})
```

Should work
