### PR TITLE
Do not allow undefined `peerInfo`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
 var Swarm = require('./swarm')
 
 exports = module.exports = Swarm
-exports.singleton = new Swarm()

--- a/src/swarm.js
+++ b/src/swarm.js
@@ -11,6 +11,10 @@ function Swarm (peerInfo) {
     throw new Error('Swarm must be called with new')
   }
 
+  if (!peerInfo) {
+    throw new Error('You must provide a value for `peerInfo`')
+  }
+
   self.peerInfo = peerInfo
 
   // peerIdB58: { conn: <conn> }

--- a/tests/swarm-test.js
+++ b/tests/swarm-test.js
@@ -24,6 +24,16 @@ process.on('uncaughtException', function (err) {
   console.log('Caught exception: ' + err)
 })
 
+experiment('Without a peer', function () {
+  test('it throws an exception', function (done) {
+    expect(function () {
+      var sw = new Swarm()
+      sw.close()
+    }).to.throw(Error)
+    done()
+  })
+})
+
 experiment('Without a Stream Muxer', function () {
   experiment('tcp', function () {
     test('add the transport', function (done) {


### PR DESCRIPTION
# What

The code assumes that `peerInfo` exists, the API doesn't.
# How to test

``` js
swarm = new Swarm()
swarm.addTransport('tcp', tcp, { multiaddr: mh }, {}, {port: 8095})
```

This shouldn't explode because of `self.peerInfo.multiaddrs`.
