### PR TITLE
attach peerId to the conn

### DIFF
--- a/test/09-swarm-with-muxing.node.js
+++ b/test/09-swarm-with-muxing.node.js
@@ -195,9 +195,25 @@ describe('high level API - with everything mixed all together!', function () {
 
     swarmA.dial(peerC, '/mamao/1.0.0', (err, conn) => {
       expect(err).to.not.exist
+      expect(conn.peerId).to.exist
       expect(Object.keys(swarmA.muxedConns).length).to.equal(2)
       conn.end()
 
+      conn.on('data', () => {}) // let it flow.. let it flooooow
+      conn.on('end', done)
+    })
+  })
+
+  it('again, so that identify had time', (done) => {
+    swarmC.handle('/mamao/1.0.0', (conn) => {
+      expect(conn.peerId).to.exist
+      conn.pipe(conn)
+    })
+
+    swarmA.dial(peerC, '/mamao/1.0.0', (err, conn) => {
+      expect(err).to.not.exist
+      expect(conn.peerId).to.exist
+      conn.end()
       conn.on('data', () => {}) // let it flow.. let it flooooow
       conn.on('end', done)
     })


### PR DESCRIPTION
This gets what we wanted/need.

Not super happy with the fact that since identify to finish (and since this is all async), there are some incoming connections that are delivered to their protocol handlers without that connId (typically just the first one, during the period where identify is still doing its thing).
