### PR TITLE
Catch unhandled exception (EADDRINUSE) in listeners

### DIFF
--- a/src/transport.js
+++ b/src/transport.js
@@ -81,7 +81,7 @@ module.exports = function (swarm) {
         return (cb) => {
           const listener = transport.createListener(handler)
 
-          listener.on('error', cb)
+          listener.once('error', cb)
 
           listener.listen(ma, () => {
             listener.getAddrs((err, addrs) => {

--- a/src/transport.js
+++ b/src/transport.js
@@ -80,6 +80,9 @@ module.exports = function (swarm) {
       const createListeners = multiaddrs.map((ma) => {
         return (cb) => {
           const listener = transport.createListener(handler)
+
+          listener.on('error', cb)
+
           listener.listen(ma, () => {
             listener.getAddrs((err, addrs) => {
               if (err) {
@@ -93,7 +96,11 @@ module.exports = function (swarm) {
         }
       })
 
-      parallel(createListeners, () => {
+      parallel(createListeners, (err) => {
+        if (err) {
+          return callback(err)
+        }
+
         // cause we can listen on port 0 or 0.0.0.0
         swarm._peerInfo.multiaddr.replace(multiaddrs, freshMultiaddrs)
         callback()

--- a/src/transport.js
+++ b/src/transport.js
@@ -84,6 +84,7 @@ module.exports = function (swarm) {
           listener.once('error', cb)
 
           listener.listen(ma, () => {
+            listener.removeListener('error', cb)
             listener.getAddrs((err, addrs) => {
               if (err) {
                 return cb(err)


### PR DESCRIPTION
This PR will make sure EADDRINUSE gets bubbled up in the callback chain so that when we try to bind a peer to an address (port) already in use, it will not cause an unhandled exception and blow up.

This fix is needed to be able to test the same behaviour ultimately in js-ipfs.