### PR TITLE
Calling distinctMultiaddr to eliminate appropriate dup multiaddrs

### DIFF
--- a/src/transport.js
+++ b/src/transport.js
@@ -67,7 +67,7 @@ module.exports = function (swarm) {
         handler = protocolMuxer.bind(null, swarm.protocols)
       }
 
-      const multiaddrs = dialables(swarm.transports[key], swarm._peerInfo.multiaddrs)
+      const multiaddrs = dialables(swarm.transports[key], swarm._peerInfo.distinctMultiaddr())
 
       const transport = swarm.transports[key]
 


### PR DESCRIPTION
Calling distinctMultiaddr should solve issue https://github.com/ipfs/js-ipfs/issues/228.  The Daemon shouldn't choke because duplicate ports have been eliminated.