### PR TITLE
Added error handling to transport.dial functionality when there is one multiaddr

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,11 +12,16 @@ const multiaddr = require('multiaddr')
 const fs = require('fs')
 const path = require('path')
 
-const sigServer = require('libp2p-webrtc-star/src/signalling-server')
+const sigServer = require('libp2p-webrtc-star/src/signalling')
 
 let swarmA
 let swarmB
 let sigS
+
+const options = {
+  port: 15555,
+  host: '127.0.0.1'
+}
 
 gulp.task('test:browser:before', (done) => {
   function createListenerA (cb) {
@@ -70,7 +75,7 @@ gulp.task('test:browser:before', (done) => {
 
   createListenerA(ready)
   createListenerB(ready)
-  sigS = sigServer.start(15555, ready)
+  sigS = sigServer.start(options, ready)
 
   function echo (protocol, conn) {
     pull(conn, conn)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "libp2p-secio": "^0.6.3",
     "libp2p-spdy": "^0.10.0",
     "libp2p-tcp": "^0.9.1",
-    "libp2p-webrtc-star": "^0.6.0",
+    "libp2p-webrtc-star": "^0.7.0",
     "libp2p-websockets": "^0.9.1",
     "pre-commit": "^1.1.3",
     "pull-goodbye": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "libp2p-secio": "^0.6.3",
     "libp2p-spdy": "^0.10.0",
     "libp2p-tcp": "^0.9.1",
-    "libp2p-webrtc-star": "^0.6.1",
+    "libp2p-webrtc-star": "^0.7.0",
     "libp2p-websockets": "^0.9.1",
     "pre-commit": "^1.1.3",
     "pull-goodbye": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "libp2p-secio": "^0.6.3",
     "libp2p-spdy": "^0.10.0",
     "libp2p-tcp": "^0.9.1",
-    "libp2p-webrtc-star": "^0.7.0",
+    "libp2p-webrtc-star": "^0.6.1",
     "libp2p-websockets": "^0.9.1",
     "pre-commit": "^1.1.3",
     "pull-goodbye": "0.0.1",

--- a/src/transport.js
+++ b/src/transport.js
@@ -41,8 +41,10 @@ module.exports = function (swarm) {
       // b) if multiaddrs.length = 1, return the conn from the
       // transport, otherwise, create a passthrough
       if (multiaddrs.length === 1) {
-        const conn = t.dial(multiaddrs.shift())
-        callback(null, new Connection(conn))
+        const conn = t.dial(multiaddrs.shift(), (err) => {
+          if (err) return callback(err)
+          callback(null, new Connection(conn))
+        })
         return
       }
 

--- a/test/browser-01-transport-webrtc-star.js
+++ b/test/browser-01-transport-webrtc-star.js
@@ -75,6 +75,14 @@ describe('transport - webrtc-star', () => {
       )
     })
   })
+  it('dial offline / non-existent node', (done) => {
+    const mhOffline = multiaddr('/libp2p-webrtc-star/ip4/127.0.0.1/tcp/15555/ws/ipfs/ABCD')
+    swarm1.transport.dial('wstar', mhOffline, (err, conn) => {
+      expect(err).to.exist
+      expect(conn).to.not.exist
+      done()
+    })
+  })
 
   it('close', (done) => {
     parallel([


### PR DESCRIPTION
Hey All,

Dialing an offline node does not currently return an error but simply returns a connection whether or not the connection was established. This PR ensures that it returns an error when there is one multiaddr for a given transport. The reason the same was not done for multiple multiaddrs is that it seems to me that code for multiple multiaddrs is not fully implemented <- will discuss in more detail by referencing code below.

NOTES
- This PR currently fails tests since it requires the signaling error handling code in libp2p/js-libp2p-webrtc-star#39 which is not available in the current release of webrtc-star.
- This PR fixes the race between signaling discovery by changing it into a simple dial error that way it is handled the same way other dial errors are. libp2p/js-libp2p-webrtc-star#5 <- this issue can be closed after this is mergerd

Thanks