### PR TITLE
Don't skip multiplex identify test anymore

### DIFF
--- a/test/04-muxing-multiplex.node.js
+++ b/test/04-muxing-multiplex.node.js
@@ -107,7 +107,7 @@ describe('stream muxing with multiplex (on TCP)', () => {
     })
   })
 
-  it.skip('enable identify to reuse incomming muxed conn', (done) => {
+  it('enable identify to reuse incomming muxed conn', (done) => {
     swarmA.connection.reuse()
     swarmC.connection.reuse()
 


### PR DESCRIPTION
If https://github.com/libp2p/js-libp2p-multiplex/pull/55 gets merged, this test passes again.

Depends on the PR referenced above