### PR TITLE
Use callback in muxer.end instead of close event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,11 +114,11 @@ function Swarm (peerInfo) {
     const key = peerInfo.id.toB58String()
     if (this.muxedConns[key]) {
       const muxer = this.muxedConns[key].muxer
-      muxer.end()
       muxer.once('close', () => {
         delete this.muxedConns[key]
         callback()
       })
+      muxer.end()
     } else {
       callback()
     }


### PR DESCRIPTION
Solves https://github.com/ipfs/js-libp2p-ipfs-nodejs/issues/58

Not sure if this is the right way to fix it though, since multiplex seems to not correctly emit close event...