### PR TITLE
feat: sort available transports by priority

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,10 +51,11 @@
     "libp2p-tcp": "~0.10.0",
     "libp2p-webrtc-star": "~0.9.0",
     "libp2p-websockets": "~0.10.0",
+    "peer-book": "~0.4.0",
     "pre-commit": "^1.2.2",
     "pull-goodbye": "0.0.1",
-    "peer-book": "~0.4.0",
     "pull-stream": "^3.5.0",
+    "sinon": "^2.1.0",
     "webrtcsupport": "^2.2.0"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,15 @@ function Swarm (peerInfo, peerBook) {
 
     // Only listen on transports we actually have addresses for
     return myTransports.filter((ts) => this.transports[ts].filter(myAddrs).length > 0)
+      .sort((a, b) => {
+        if ((this.transports[a] && this.transports[b]) &&
+          (this.transports[a].priority && this.transports[b].priority)) {
+          return this.transports[a].priority - this.transports[b].priority
+        }
+
+        return 0
+      })
+
   }
 
   // higher level (public) API

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ const protocolMuxer = require('./protocol-muxer')
 const plaintext = require('./plaintext')
 const assert = require('assert')
 
+const DEFAULT_TRANSPORT_PRIORITY = 1
+
 exports = module.exports = Swarm
 
 util.inherits(Swarm, EE)
@@ -64,14 +66,11 @@ function Swarm (peerInfo, peerBook) {
     // Only listen on transports we actually have addresses for
     return myTransports.filter((ts) => this.transports[ts].filter(myAddrs).length > 0)
       .sort((a, b) => {
-        if ((this.transports[a] && this.transports[b]) &&
-          (this.transports[a].priority && this.transports[b].priority)) {
-          return this.transports[a].priority - this.transports[b].priority
-        }
+        let pRa = a.priority || DEFAULT_TRANSPORT_PRIORITY
+        let pRb = b.priority || DEFAULT_TRANSPORT_PRIORITY
 
-        return 0
+        return pRa - pRb
       })
-
   }
 
   // higher level (public) API


### PR DESCRIPTION
This uses the the priority property added in the bellow PRs to prioritize order of transport dialing.

https://github.com/libp2p/js-libp2p-tcp/pull/78 (see this for discussion)
https://github.com/libp2p/js-libp2p-websockets/pull/61

If we decide to go with this, we'd need to add `priority` to the remaining transports as well.

