### PR TITLE
Fix callback bug

### DIFF
--- a/src/dial.js
+++ b/src/dial.js
@@ -186,14 +186,14 @@ function dial (swarm) {
       const ms = new multistream.Dialer()
       ms.handle(conn, (err) => {
         if (err) {
-          return callback(err)
+          return cb(err)
         }
         ms.select(protocol, (err, conn) => {
           if (err) {
-            return callback(err)
+            return cb(err)
           }
           proxyConn.setInnerConn(conn)
-          callback(null, proxyConn)
+          cb(null, proxyConn)
         })
       })
     }


### PR DESCRIPTION
The top-level callback was called instead of the supplied cb callback