### PR TITLE
fix: don't dial circuit if no transports available

### DIFF
--- a/src/dial.js
+++ b/src/dial.js
@@ -83,6 +83,10 @@ function dial (swarm) {
     function attemptDial (pi, cb) {
       const tKeys = swarm.availableTransports(pi)
 
+      if (tKeys.length === 0) {
+        return cb(new Error('No transports registered, dial not possible'))
+      }
+
       nextTransport(tKeys.shift())
 
       function nextTransport (key) {

--- a/test/circuit.js
+++ b/test/circuit.js
@@ -102,12 +102,12 @@ describe(`circuit`, function () {
     })
   })
 
-  it(`should not try circuit if not enabled`, function (done) {
+  it(`should not try circuit if no transports enabled`, function (done) {
     swarmC.dial(peerA, (err, conn) => {
       expect(err).to.exist()
       expect(conn).to.not.exist()
 
-      expect(err).to.match(/Could not dial in any of the transports or relays/)
+      expect(err).to.match(/No transports registered, dial not possible/)
       done()
     })
   })


### PR DESCRIPTION
Currently, if there are no transports registered `libp2p-swarm` will still try to dial over circuit relay. This PR adds an error to signal that no protocols are registered for dialing.