### PR TITLE
fix: switch observer edge cases

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -30,8 +30,10 @@ module.exports = (swtch) => {
 
   function willObserve (peerInfo, transport, protocol, direction, bufferLength) {
     peerInfo.then((pi) => {
-      const peerId = pi.id.toB58String()
-      setImmediate(() => observer.emit('message', peerId, transport, protocol, direction, bufferLength))
+      if (pi) {
+        const peerId = pi.id.toB58String()
+        setImmediate(() => observer.emit('message', peerId, transport, protocol, direction, bufferLength))
+      }
     })
   }
 }

--- a/src/protocol-muxer.js
+++ b/src/protocol-muxer.js
@@ -14,8 +14,11 @@ module.exports = function protocolMuxer (protocols, observer) {
       }
 
       const handler = (protocol, _conn) => {
-        const conn = observeConn(null, protocol, _conn, observer)
-        protocols[protocol].handlerFunc.call(null, protocol, conn)
+        const handlerFunc = protocols[protocol].handlerFunc
+        if (handlerFunc) {
+          const conn = observeConn(null, protocol, _conn, observer)
+          handlerFunc(protocol, conn)
+        }
       }
 
       ms.addHandler(protocol, handler, protocols[protocol].matchFunc)


### PR DESCRIPTION
For when:

* there is not protocol handler funcion
* peerInfo resolves to `undefined`