### PR TITLE
refactor: update files and add jsdocs to improve readability

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -143,8 +143,6 @@ class ConnectionManager {
         Object.assign(config, { hop: { enabled: false, active: false } })
       }
 
-      // TODO: (dryajov) should we enable circuit listener and
-      // dialer by default?
       this.switch.transport.add(Circuit.tag, new Circuit(this.switch, config))
     }
   }

--- a/src/connection.js
+++ b/src/connection.js
@@ -12,121 +12,155 @@ const Circuit = require('libp2p-circuit')
 
 const plaintext = require('./plaintext')
 
-module.exports = function connection (swtch) {
-  return {
-    addUpgrade () {},
+/**
+ * Contains methods for binding handlers to the Switch
+ * in order to better manage its connections.
+ */
+class ConnectionManager {
+  constructor (_switch) {
+    this.switch = _switch
+  }
 
-    addStreamMuxer (muxer) {
-      // for dialing
-      swtch.muxers[muxer.multicodec] = muxer
+  /**
+   * Adds a listener for the given `muxer` and creates a handler for it
+   * leveraging the Switch.protocolMuxer handler factory
+   *
+   * @param {Muxer} muxer
+   * @returns {void}
+   */
+  addStreamMuxer (muxer) {
+    // for dialing
+    this.switch.muxers[muxer.multicodec] = muxer
 
-      // for listening
-      swtch.handle(muxer.multicodec, (protocol, conn) => {
-        const muxedConn = muxer.listener(conn)
+    // for listening
+    this.switch.handle(muxer.multicodec, (protocol, conn) => {
+      const muxedConn = muxer.listener(conn)
 
-        muxedConn.on('stream', swtch.protocolMuxer(null))
+      muxedConn.on('stream', this.switch.protocolMuxer(null))
 
-        // If identify is enabled
-        //   1. overload getPeerInfo
-        //   2. call getPeerInfo
-        //   3. add this conn to the pool
-        if (swtch.identify) {
-          // overload peerInfo to use Identify instead
-          conn.getPeerInfo = (cb) => {
-            const conn = muxedConn.newStream()
-            const ms = new multistream.Dialer()
-            cb = once(cb)
+      // If identify is enabled
+      //   1. overload getPeerInfo
+      //   2. call getPeerInfo
+      //   3. add this conn to the pool
+      if (this.switch.identify) {
+        // overload peerInfo to use Identify instead
+        conn.getPeerInfo = (callback) => {
+          const conn = muxedConn.newStream()
+          const ms = new multistream.Dialer()
+          callback = once(callback)
 
-            waterfall([
-              (cb) => ms.handle(conn, cb),
-              (cb) => ms.select(identify.multicodec, cb),
-              (conn, cb) => identify.dialer(conn, cb),
-              (peerInfo, observedAddrs, cb) => {
-                observedAddrs.forEach((oa) => {
-                  swtch._peerInfo.multiaddrs.addSafe(oa)
-                })
-                cb(null, peerInfo)
-              }
-            ], (err, pi) => {
-              if (pi) {
-                conn.setPeerInfo(pi)
-              }
-              cb(err, pi)
-            })
-          }
-
-          conn.getPeerInfo((err, peerInfo) => {
-            if (err) {
-              return log('Identify not successful')
+          waterfall([
+            (cb) => ms.handle(conn, cb),
+            (cb) => ms.select(identify.multicodec, cb),
+            (conn, cb) => identify.dialer(conn, cb),
+            (peerInfo, observedAddrs, cb) => {
+              observedAddrs.forEach((oa) => {
+                this.switch._peerInfo.multiaddrs.addSafe(oa)
+              })
+              cb(null, peerInfo)
             }
-            const b58Str = peerInfo.id.toB58String()
-
-            swtch.muxedConns[b58Str] = { muxer: muxedConn }
-
-            if (peerInfo.multiaddrs.size > 0) {
-              // with incomming conn and through identify, going to pick one
-              // of the available multiaddrs from the other peer as the one
-              // I'm connected to as we really can't be sure at the moment
-              // TODO add this consideration to the connection abstraction!
-              peerInfo.connect(peerInfo.multiaddrs.toArray()[0])
-            } else {
-              // for the case of websockets in the browser, where peers have
-              // no addr, use just their IPFS id
-              peerInfo.connect(`/ipfs/${b58Str}`)
+          ], (err, peerInfo) => {
+            if (peerInfo) {
+              conn.setPeerInfo(peerInfo)
             }
-            peerInfo = swtch._peerBook.put(peerInfo)
-
-            muxedConn.on('close', () => {
-              delete swtch.muxedConns[b58Str]
-              peerInfo.disconnect()
-              peerInfo = swtch._peerBook.put(peerInfo)
-              setImmediate(() => swtch.emit('peer-mux-closed', peerInfo))
-            })
-
-            setImmediate(() => swtch.emit('peer-mux-established', peerInfo))
+            callback(err, peerInfo)
           })
         }
 
-        return conn
-      })
-    },
+        conn.getPeerInfo((err, peerInfo) => {
+          if (err) {
+            return log('Identify not successful')
+          }
+          const b58Str = peerInfo.id.toB58String()
 
-    reuse () {
-      swtch.identify = true
-      swtch.handle(identify.multicodec, (protocol, conn) => {
-        identify.listener(conn, swtch._peerInfo)
-      })
-    },
+          this.switch.muxedConns[b58Str] = { muxer: muxedConn }
 
-    enableCircuitRelay (config) {
-      config = config || {}
+          if (peerInfo.multiaddrs.size > 0) {
+            // with incomming conn and through identify, going to pick one
+            // of the available multiaddrs from the other peer as the one
+            // I'm connected to as we really can't be sure at the moment
+            // TODO add this consideration to the connection abstraction!
+            peerInfo.connect(peerInfo.multiaddrs.toArray()[0])
+          } else {
+            // for the case of websockets in the browser, where peers have
+            // no addr, use just their IPFS id
+            peerInfo.connect(`/ipfs/${b58Str}`)
+          }
+          peerInfo = this.switch._peerBook.put(peerInfo)
 
-      if (config.enabled) {
-        if (!config.hop) {
-          Object.assign(config, { hop: { enabled: false, active: false } })
-        }
+          muxedConn.on('close', () => {
+            delete this.switch.muxedConns[b58Str]
+            peerInfo.disconnect()
+            peerInfo = this.switch._peerBook.put(peerInfo)
+            setImmediate(() => this.switch.emit('peer-mux-closed', peerInfo))
+          })
 
-        // TODO: (dryajov) should we enable circuit listener and
-        // dialer by default?
-        swtch.transport.add(Circuit.tag, new Circuit(swtch, config))
-      }
-    },
-
-    crypto (tag, encrypt) {
-      if (!tag && !encrypt) {
-        tag = plaintext.tag
-        encrypt = plaintext.encrypt
-      }
-
-      swtch.unhandle(swtch.crypto.tag)
-      swtch.handle(tag, (protocol, conn) => {
-        const myId = swtch._peerInfo.id
-        const secure = encrypt(myId, conn, undefined, () => {
-          swtch.protocolMuxer(null)(secure)
+          setImmediate(() => this.switch.emit('peer-mux-established', peerInfo))
         })
-      })
+      }
 
-      swtch.crypto = {tag, encrypt}
+      return conn
+    })
+  }
+
+  /**
+   * Adds the `encrypt` handler for the given `tag` and also sets the
+   * Switch's crypto to past `encrypt` function
+   *
+   * @param {String} tag
+   * @param {function(PeerID, Connection, PeerId, Callback)} encrypt
+   * @returns {void}
+   */
+  crypto (tag, encrypt) {
+    if (!tag && !encrypt) {
+      tag = plaintext.tag
+      encrypt = plaintext.encrypt
+    }
+
+    this.switch.unhandle(this.switch.crypto.tag)
+    this.switch.handle(tag, (protocol, conn) => {
+      const myId = this.switch._peerInfo.id
+      const secure = encrypt(myId, conn, undefined, () => {
+        this.switch.protocolMuxer(null)(secure)
+      })
+    })
+
+    this.switch.crypto = {tag, encrypt}
+  }
+
+  /**
+   * If config.enabled is true, a Circuit relay will be added to the
+   * available Switch transports.
+   *
+   * @param {any} config
+   * @returns {void}
+   */
+  enableCircuitRelay (config) {
+    config = config || {}
+
+    if (config.enabled) {
+      if (!config.hop) {
+        Object.assign(config, { hop: { enabled: false, active: false } })
+      }
+
+      // TODO: (dryajov) should we enable circuit listener and
+      // dialer by default?
+      this.switch.transport.add(Circuit.tag, new Circuit(this.switch, config))
     }
   }
+
+  /**
+   * Sets identify to true on the Switch and performs handshakes
+   * for libp2p-identify leveraging the Switch's muxer.
+   *
+   * @returns {void}
+   */
+  reuse () {
+    this.switch.identify = true
+    this.switch.handle(identify.multicodec, (protocol, conn) => {
+      identify.listener(conn, this.switch._peerInfo)
+    })
+  }
 }
+
+module.exports = ConnectionManager

--- a/src/dial.js
+++ b/src/dial.js
@@ -256,23 +256,24 @@ class Dialer {
 
     const tKeys = this.switch.availableTransports(this.peerInfo)
 
-    const circuitEnabled = Boolean(swtch.transports[Circuit.tag])
+    const circuitEnabled = Boolean(this.switch.transports[Circuit.tag])
     let circuitTried = false
 
     const nextTransport = (key) => {
       let transport = key
+      const b58Id = this.peerInfo.id.toB58String()
       if (!transport) {
         if (!circuitEnabled) {
-          const msg = `Circuit not enabled and all transports failed to dial peer ${pi.id.toB58String()}!`
-          return cb(new Error(msg))
+          const msg = `Circuit not enabled and all transports failed to dial peer ${b58Id}!`
+          return callback(new Error(msg))
         }
 
         if (circuitTried) {
-          return cb(new Error(`No available transports to dial peer ${pi.id.toB58String()}!`))
+          return callback(new Error(`No available transports to dial peer ${b58Id}!`))
         }
 
         log(`Falling back to dialing over circuit`)
-        this.peerInfo.multiaddrs.add(`/p2p-circuit/ipfs/${this.peerInfo.id.toB58String()}`)
+        this.peerInfo.multiaddrs.add(`/p2p-circuit/ipfs/${b58Id}`)
         circuitTried = true
         transport = Circuit.tag
       }

--- a/src/dial.js
+++ b/src/dial.js
@@ -108,6 +108,13 @@ class Dialer {
    */
   _createBaseConnection (b58Id, callback) {
     const baseConnection = this.switch.conns[b58Id]
+    const muxedConnection = this.switch.muxedConns[b58Id]
+
+    // if the muxed connection exists, dont return a connection,
+    // _createMuxedConnection will get the connection
+    if (muxedConnection) {
+      return callback(null, null)
+    }
     if (baseConnection) {
       this.switch.conns[b58Id] = undefined
       return callback(null, baseConnection)

--- a/src/observe-connection.js
+++ b/src/observe-connection.js
@@ -3,17 +3,29 @@
 const Connection = require('interface-connection').Connection
 const pull = require('pull-stream')
 
-module.exports = (transport, protocol, _conn, observer) => {
+/**
+ * Creates a pull stream to run the given Connection stream through
+ * the given Observer. This provides a way to more easily monitor connections
+ * and their metadata. A new Connection will be returned that contains
+ * has the attached Observer.
+ *
+ * @param {Transport} transport
+ * @param {string} protocol
+ * @param {Connection} connection
+ * @param {Observer} observer
+ * @returns {Connection}
+ */
+module.exports = (transport, protocol, connection, observer) => {
   const peerInfo = new Promise((resolve, reject) => {
-    _conn.getPeerInfo((err, peerInfo) => {
+    connection.getPeerInfo((err, peerInfo) => {
       if (!err && peerInfo) {
         resolve(peerInfo)
         return
       }
 
-      const setPeerInfo = _conn.setPeerInfo
-      _conn.setPeerInfo = (pi) => {
-        setPeerInfo.call(_conn, pi)
+      const setPeerInfo = connection.setPeerInfo
+      connection.setPeerInfo = (pi) => {
+        setPeerInfo.call(connection, pi)
         resolve(pi)
       }
     })
@@ -21,11 +33,12 @@ module.exports = (transport, protocol, _conn, observer) => {
 
   const stream = {
     source: pull(
-      _conn,
+      connection,
       observer.incoming(transport, protocol, peerInfo)),
     sink: pull(
       observer.outgoing(transport, protocol, peerInfo),
-      _conn)
+      connection)
   }
-  return new Connection(stream, _conn)
+
+  return new Connection(stream, connection)
 }

--- a/src/observer.js
+++ b/src/observer.js
@@ -3,6 +3,15 @@
 const pull = require('pull-stream')
 const EventEmitter = require('events')
 
+/**
+ * Takes a Switch and returns an Observer that can be used in conjunction with
+ * observe-connection.js. The returned Observer comes with `incoming` and
+ * `outgoing` properties that can be used in pull streams to emit all metadata
+ * for messages that pass through a Connection.
+ *
+ * @param {Switch} swtch
+ * @returns {EventEmitter}
+ */
 module.exports = (swtch) => {
   const observer = Object.assign(new EventEmitter(), {
     incoming: observe('in'),
@@ -29,9 +38,9 @@ module.exports = (swtch) => {
   }
 
   function willObserve (peerInfo, transport, protocol, direction, bufferLength) {
-    peerInfo.then((pi) => {
-      if (pi) {
-        const peerId = pi.id.toB58String()
+    peerInfo.then((_peerInfo) => {
+      if (_peerInfo) {
+        const peerId = _peerInfo.id.toB58String()
         setImmediate(() => observer.emit('message', peerId, transport, protocol, direction, bufferLength))
       }
     })

--- a/src/plaintext.js
+++ b/src/plaintext.js
@@ -2,6 +2,10 @@
 
 const setImmediate = require('async/setImmediate')
 
+/**
+ * An encryption stub in the instance that the default crypto
+ * has not been overriden for the Switch
+ */
 module.exports = {
   tag: '/plaintext/1.0.0',
   encrypt (myId, conn, remoteId, callback) {

--- a/src/stats/index.js
+++ b/src/stats/index.js
@@ -26,6 +26,15 @@ const directionToEvent = {
   out: 'dataSent'
 }
 
+/**
+ * Binds to message events on the given `observer` to generate stats
+ * based on the Peer, Protocol and Transport used for the message. Stat
+ * events will be emitted via the `update` event.
+ *
+ * @param {Observer} observer
+ * @param {any} _options
+ * @returns {Stats}
+ */
 module.exports = (observer, _options) => {
   const options = Object.assign({}, defaultOptions, _options)
   const globalStats = new Stat(initialCounters, options)

--- a/src/stats/old-peers.js
+++ b/src/stats/old-peers.js
@@ -2,6 +2,12 @@
 
 const LRU = require('quick-lru')
 
+/**
+ * Creates and returns a Least Recently Used Cache
+ *
+ * @param {Number} maxSize
+ * @returns {LRUCache}
+ */
 module.exports = (maxSize) => {
   return new LRU({ maxSize: maxSize })
 }

--- a/src/stats/stat.js
+++ b/src/stats/stat.js
@@ -4,6 +4,12 @@ const EventEmitter = require('events')
 const Big = require('big.js')
 const MovingAverage = require('moving-average')
 
+/**
+ * A queue based manager for stat processing
+ *
+ * @param {Array<string>} initialCounters
+ * @param {any} options
+ */
 class Stats extends EventEmitter {
   constructor (initialCounters, options) {
     super()
@@ -28,31 +34,68 @@ class Stats extends EventEmitter {
     })
   }
 
+  /**
+   * Initializes the internal timer if there are items in the queue. This
+   * should only need to be called if `Stats.stop` was previously called, as
+   * `Stats.push` will also start the processing.
+   *
+   * @returns {void}
+   */
   start () {
     if (this._queue.length) {
       this._resetComputeTimeout()
     }
   }
 
+  /**
+   * Stops processing and computing of stats by clearing the internal
+   * timer.
+   *
+   * @returns {void}
+   */
   stop () {
     if (this._timeout) {
       clearTimeout(this._timeout)
     }
   }
 
+  /**
+   * Returns a clone of the current stats.
+   *
+   * @returns {Map<string, Stat>}
+   */
   get snapshot () {
     return Object.assign({}, this._stats)
   }
 
+  /**
+   * Returns a clone of the internal movingAverages
+   *
+   * @returns {Array<MovingAverage>}
+   */
   get movingAverages () {
     return Object.assign({}, this._movingAverages)
   }
 
+  /**
+   * Pushes the given operation data to the queue, along with the
+   * current Timestamp, then resets the update timer.
+   *
+   * @param {string} counter
+   * @param {number} inc
+   * @returns {void}
+   */
   push (counter, inc) {
     this._queue.push([counter, inc, Date.now()])
     this._resetComputeTimeout()
   }
 
+  /**
+   * Resets the timeout for triggering updates.
+   *
+   * @private
+   * @returns {void}
+   */
   _resetComputeTimeout () {
     if (this._timeout) {
       clearTimeout(this._timeout)
@@ -60,6 +103,13 @@ class Stats extends EventEmitter {
     this._timeout = setTimeout(this._update, this._nextTimeout())
   }
 
+  /**
+   * Calculates and returns the timeout for the next update based on
+   * the urgency of the update.
+   *
+   * @private
+   * @returns {number}
+   */
   _nextTimeout () {
     // calculate the need for an update, depending on the queue length
     const urgency = this._queue.length / this._options.computeThrottleMaxQueueSize
@@ -67,6 +117,17 @@ class Stats extends EventEmitter {
     return timeout
   }
 
+  /**
+   * If there are items in the queue, they will will be processed and
+   * the frequency for all items will be updated based on the Timestamp
+   * of the last item in the queue. The `update` event will also be emitted
+   * with the latest stats.
+   *
+   * If there are no items in the queue, no action is taken.
+   *
+   * @private
+   * @returns {void}
+   */
   _update () {
     this._timeout = null
     if (this._queue.length) {
@@ -82,6 +143,15 @@ class Stats extends EventEmitter {
     }
   }
 
+  /**
+   * For each key in the stats, the frequncy and moving averages
+   * will be updated via Stats._updateFrequencyFor based on the time
+   * difference between calls to this method.
+   *
+   * @private
+   * @param {Timestamp} latestTime
+   * @returns {void}
+   */
   _updateFrequency (latestTime) {
     const timeDiff = latestTime - this._frequencyLastTime
 
@@ -92,6 +162,16 @@ class Stats extends EventEmitter {
     this._frequencyLastTime = latestTime
   }
 
+  /**
+   * Updates the `movingAverages` for the given `key` and also
+   * resets the `frequencyAccumulator` for the `key`.
+   *
+   * @private
+   * @param {string} key
+   * @param {number} timeDiffMS Time in milliseconds
+   * @param {Timestamp} latestTime Time in ticks
+   * @returns {void}
+   */
   _updateFrequencyFor (key, timeDiffMS, latestTime) {
     const count = this._frequencyAccumulators[key] || 0
     this._frequencyAccumulators[key] = 0
@@ -110,6 +190,15 @@ class Stats extends EventEmitter {
     })
   }
 
+  /**
+   * For the given operation, `op`, the stats and `frequencyAccumulator`
+   * will be updated or initialized if they don't already exist.
+   *
+   * @private
+   * @param {Array<string, number>} op
+   * @throws {InvalidNumber}
+   * @returns {void}
+   */
   _applyOp (op) {
     const key = op[0]
     const inc = op[1]

--- a/test/circuit-relay.node.js
+++ b/test/circuit-relay.node.js
@@ -72,8 +72,8 @@ describe(`circuit`, function () {
   })
 
   it('listed on the transports map', () => {
-    expect(swarmA.transports['Circuit']).to.exist()
-    expect(swarmB.transports['Circuit']).to.exist()
+    expect(swarmA.transports.Circuit).to.exist()
+    expect(swarmB.transports.Circuit).to.exist()
   })
 
   it('add /p2p-curcuit addrs on start', (done) => {

--- a/test/get-peer-info.spec.js
+++ b/test/get-peer-info.spec.js
@@ -1,0 +1,73 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+
+const PeerBook = require('peer-book')
+const PeerInfo = require('peer-info')
+const PeerId = require('peer-id')
+const MultiAddr = require('multiaddr')
+const TestPeerInfos = require('./test-data/ids.json').infos
+
+const getPeerInfo = require('../src/get-peer-info')
+
+describe('Get peer info', () => {
+  let peerBook
+  let peerInfoA
+  let multiaddrA
+  let peerIdA
+
+  before((done) => {
+    peerBook = new PeerBook()
+    PeerId.createFromJSON(TestPeerInfos[0].id, (err, id) => {
+      peerIdA = id
+      peerInfoA = new PeerInfo(peerIdA)
+      multiaddrA = MultiAddr('/ipfs/QmdWYwTywvXBeLKWthrVNjkq9SafEDn1PbAZdz4xZW7Jd9')
+      peerInfoA.multiaddrs.add(multiaddrA)
+      peerBook.put(peerInfoA)
+      done(err)
+    })
+  })
+
+  it('should be able get peer info from multiaddr', () => {
+    let _peerInfo = getPeerInfo(multiaddrA, peerBook)
+    expect(peerBook.has(_peerInfo)).to.equal(true)
+    expect(peerInfoA).to.deep.equal(_peerInfo)
+  })
+
+  it('should return a new PeerInfo with a multiAddr not in the PeerBook', () => {
+    let wrongMultiAddr = MultiAddr('/ipfs/QmckZzdVd72h9QUFuJJpQqhsZqGLwjhh81qSvZ9BhB2FQi')
+    let _peerInfo = getPeerInfo(wrongMultiAddr, peerBook)
+    expect(PeerInfo.isPeerInfo(_peerInfo)).to.equal(true)
+    expect(peerBook.has(_peerInfo)).to.equal(false)
+  })
+
+  it('should be able get peer info from peer id', () => {
+    let _peerInfo = getPeerInfo(multiaddrA, peerBook)
+    expect(peerBook.has(_peerInfo)).to.equal(true)
+    expect(peerInfoA).to.deep.equal(_peerInfo)
+  })
+
+  it('should not be able to get the peer info for a wrong peer id', (done) => {
+    PeerId.createFromJSON(TestPeerInfos[1].id, (err, id) => {
+      let func = () => {
+        getPeerInfo(id, peerBook)
+      }
+
+      expect(func).to.throw('Couldnt get PeerInfo')
+
+      done(err)
+    })
+  })
+
+  it('an invalid peer type should throw an error', () => {
+    let func = () => {
+      getPeerInfo('/ip4/127.0.0.1/tcp/1234', peerBook)
+    }
+
+    expect(func).to.throw('peer type not recognized')
+  })
+})


### PR DESCRIPTION
In preparation for the changes that will need to occur to get the Private Network implemented, libp2p/js-libp2p#163, I started doing some refactoring to the Switch in order to improve readability and update jsdocs throughout the repo. I think this refactor will also make it easier to turn Switch into a state machine libp2p/js-libp2p-switch#24.

There is still some more work I would like to do with this, but I wanted to get visibility to this sooner rather than later. As someone who was really diving into this repo for the first time, it was difficult to get up to speed on everything that's going on, especially in dial.js. I think this helps provide more clarity to that and should make it easier for others to contribute in the future.

I'd love some feedback on these changes.

**Update**: Okay, I've done some more refactoring, added additional jsdocs and comments and added in some tests for the get-peer-info.js file.  I think this is in a good position to get merged in. I avoided making any significant logic changes for this so that it's a pure refactor. I'd like to build the state machine and private network efforts of of this if possible.

## Verified against
The refactor will be checked against the following repos by locally linking switch to the repo's and running their test suites.

- [x] libp2p/js-libp2p
- [x] ipfs/js-ipfs
- [x] ipfs/interop