### PR TITLE
feat: swap quick-lru by hashlru

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "async": "^2.6.0",
     "big.js": "^5.0.3",
     "debug": "^3.1.0",
+    "hashlru": "^2.2.1",
     "interface-connection": "~0.3.2",
     "ip-address": "^5.8.9",
     "libp2p-circuit": "~0.2.0",
@@ -68,8 +69,7 @@
     "once": "^1.4.0",
     "peer-id": "~0.10.7",
     "peer-info": "~0.14.1",
-    "pull-stream": "^3.6.7",
-    "quick-lru": "^1.1.0"
+    "pull-stream": "^3.6.7"
   },
   "contributors": [
     "Arnaud <arnaud.valensi@gmail.com>",

--- a/src/stats/old-peers.js
+++ b/src/stats/old-peers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const LRU = require('quick-lru')
+const LRU = require('hashlru')
 
 /**
  * Creates and returns a Least Recently Used Cache
@@ -9,5 +9,7 @@ const LRU = require('quick-lru')
  * @returns {LRUCache}
  */
 module.exports = (maxSize) => {
-  return new LRU({ maxSize: maxSize })
+  const patched = LRU(maxSize)
+  patched.delete = patched.remove
+  return patched
 }


### PR DESCRIPTION
This removes the only dependency using generators in the ipfs/libp2p ecosystem.
Next version of create-react-app will support ipfs out-of-box with this change.

hashlru is the original implementation sindre used for quicklru
https://github.com/sindresorhus/quick-lru
>Inspired by the hashlru algorithm, but instead uses Map to support keys of any type, not just strings, and values can be undefined.

Browser bundling ecosystem is moving towards running babel preset env through the dependencies and stop relying on pre built bundles to optimize end user bundles. But babel preset env handles everything but generators, this change will make any package that uses `js-libp2p-switch` more compatible.