### PR TITLE
fix: prevent undefined error during a mutual hangup

### DIFF
--- a/src/dial.js
+++ b/src/dial.js
@@ -267,8 +267,9 @@ class Dialer {
           }
 
           const muxedConn = this.switch.muxers[key].dialer(conn)
-          this.switch.muxedConns[b58Id] = {}
-          this.switch.muxedConns[b58Id].muxer = muxedConn
+          this.switch.muxedConns[b58Id] = {
+            muxer: muxedConn
+          }
 
           muxedConn.once('close', () => {
             delete this.switch.muxedConns[b58Id]

--- a/src/index.js
+++ b/src/index.js
@@ -110,6 +110,11 @@ class Switch extends EE {
     this.stats.stop()
     series([
       (cb) => each(this.muxedConns, (conn, cb) => {
+        // If the connection was destroyed while we are hanging up, continue
+        if (!conn) {
+          return cb()
+        }
+
         conn.muxer.end((err) => {
           // If OK things are fine, and someone just shut down
           if (err && err.message !== 'Fatal error: OK') {


### PR DESCRIPTION
This resolves an issue where if connected nodes hang up at the same time, such as during testing, a muxedConnection could be deleted from the switch at the same time as it's async iteration was occurring to end those connections. This would result in an undefined error.

This PR ensures we don't attempt to close connections that have been hung up on.

You can see the passing CI build for js-libp2p that uses this branch here: https://ci.ipfs.team/blue/organizations/jenkins/libp2p%2Fjs-libp2p/detail/chore%2Fupdate-switch/4/pipeline

connects to https://github.com/libp2p/js-libp2p/issues/198