### PR TITLE
fix: return on call to nextMuxer

### DIFF
--- a/src/dial.js
+++ b/src/dial.js
@@ -208,7 +208,7 @@ class Dialer {
             return callback(new Error('could not upgrade to stream muxing'))
           }
 
-          nextMuxer(muxers.shift())
+          return nextMuxer(muxers.shift())
         }
 
         const muxedConn = this.switch.muxers[key].dialer(conn)


### PR DESCRIPTION
When the call to multistream.Dialer.select is unsuccessful, call nextMuxer to try select the next one in the list but do not continue executing callback afterwards.