### PR TITLE
Fix compatibility with Parcel bundler

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "async": "^2.6.0",
-    "big.js": "^5.0.3",
+    "big.js": "^5.1.2",
     "debug": "^3.1.0",
     "hashlru": "^2.2.1",
     "interface-connection": "~0.3.2",

--- a/src/stats/stat.js
+++ b/src/stats/stat.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const EventEmitter = require('events')
-const Big = require('big.js')
+const Big = require('big.js').Big
 const MovingAverage = require('moving-average')
 
 /**


### PR DESCRIPTION
I was trying to run libp2p in the browser with the Parcel bundler. However it would always fail at 'js-libp2p-switch/stats/stat.js' with the error that `Big is not a function`. It appears that `Big` gets imported as an object `{ default: [Function], Big: [Function], __esModule: true }` but the code is trying to run it directly. 

Big.js is now an ES6 module which exports "default" and "Big" fields (which are both the same function). 