### PR TITLE
[bugfix] stats - observer expects protocolTag

### DIFF
--- a/src/protocol-muxer.js
+++ b/src/protocol-muxer.js
@@ -18,7 +18,7 @@ module.exports = function protocolMuxer (protocols, observer) {
         if (protocol) {
           const handlerFunc = protocol && protocol.handlerFunc
           if (handlerFunc) {
-            const conn = observeConn(null, protocol, _conn, observer)
+            const conn = observeConn(null, protocolName, _conn, observer)
             handlerFunc(protocol, conn)
           }
         }


### PR DESCRIPTION
bug was introduced here when `protocol` variable was renamed, but not all usages were renamed
https://github.com/libp2p/js-libp2p-switch/commit/6265ec639ac7c42e81221320152fde36b83b2dd2