### PR TITLE
Fix/dial proto stats

### DIFF
--- a/src/dial.js
+++ b/src/dial.js
@@ -409,8 +409,12 @@ class Dialer {
       }
 
       selectSafe(msDialer, this.protocol, (err, _conn) => {
+        if (err) {
+          log(`could not perform protocol handshake: `, err)
+          return callback(err)
+        }
         const conn = observeConnection(null, this.protocol, _conn, this.switch.observer)
-        callback(err, conn)
+        callback(null, conn)
       }, callback)
     }, callback)
   }

--- a/src/protocol-muxer.js
+++ b/src/protocol-muxer.js
@@ -3,9 +3,15 @@
 const multistream = require('multistream-select')
 const observeConn = require('./observe-connection')
 
+const debug = require('debug')
+const log = debug('libp2p:switch:protocol-muxer')
+
 module.exports = function protocolMuxer (protocols, observer) {
   return (transport) => (_parentConn) => {
-    const parentConn = observeConn(transport, null, _parentConn, observer)
+    const parentConn = transport
+      ? observeConn(transport, null, _parentConn, observer)
+      : _parentConn
+
     const ms = new multistream.Listener()
 
     Object.keys(protocols).forEach((protocol) => {
@@ -14,6 +20,7 @@ module.exports = function protocolMuxer (protocols, observer) {
       }
 
       const handler = (protocolName, _conn) => {
+        log(`registering handler with protocol ${protocolName}`)
         const protocol = protocols[protocolName]
         if (protocol) {
           const handlerFunc = protocol && protocol.handlerFunc

--- a/test/stats.node.js
+++ b/test/stats.node.js
@@ -174,8 +174,8 @@ describe('Stats', () => {
       expect(err).to.not.exist()
       switches.forEach((swtch) => {
         let snapshot = swtch.stats.forProtocol('/echo/1.0.0').snapshot
-        expect(snapshot.dataReceived.toFixed()).to.equal('4')
-        expect(snapshot.dataSent.toFixed()).to.equal('4')
+        expect(snapshot.dataReceived.toFixed()).to.equal('8')
+        expect(snapshot.dataSent.toFixed()).to.equal('8')
       })
       teardown(switches, done)
     })


### PR DESCRIPTION
Protocol stats were not being counted correctly for dialer multistreams. Also, multiplexed connections where also not being tracked on multiplex creation, but where being counted as multistream protos on the listener end.