### PR TITLE
ws error pull swarm

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -79,7 +79,7 @@ class ConnectionManager {
             // with incomming conn and through identify, going to pick one
             // of the available multiaddrs from the other peer as the one
             // I'm connected to as we really can't be sure at the moment
-            // TODO add this consideration to the connection abstraction!
+            // This is TODO: add this consideration to the connection abstraction!
             peerInfo.connect(peerInfo.multiaddrs.toArray()[0])
           } else {
             // for the case of websockets in the browser, where peers have

--- a/src/index.js
+++ b/src/index.js
@@ -97,17 +97,17 @@ class Switch extends EE {
     each(this.availableTransports(this._peerInfo), (ts, cb) => {
       // Listen on the given transport
       this.transport.listen(ts, {}, null, cb)
-    }, (res) => {
-      if (res !== null &&
-        typeof res.err !=='undefined' &&
-        typeof res.index !== 'undefined') {
+    }, (err) => {
+      if (err !== null &&
+        typeof err !=='undefined' &&
+        typeof err.badswarm.index !== 'undefined') {
         // Get swarm list
         const swarmArray = this._peerInfo.multiaddrs._multiaddrs
         // Output error in console
-        console.error(`Error connect to ${res.address}, error type is ${res.err.message}, check other swarm`);
+        console.log(`Error connect to ${err.badswarm.address}, error type is ${err.message}, check other swarm`);
         // Delete not working swarm
         if (swarmArray.length > 0) {
-          swarmArray.splice(res.index, 1)
+          swarmArray.splice(err.badswarm.index, 1)
         } else {
           throw new Error(`All swarm it's down`)
         }

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,9 @@ const Observer = require('./observer')
 const Stats = require('./stats')
 const assert = require('assert')
 
+const debug = require('debug')
+const log = debug('libp2p:switch:index')
+
 class Switch extends EE {
   constructor (peerInfo, peerBook, options) {
     super()
@@ -99,12 +102,12 @@ class Switch extends EE {
       this.transport.listen(ts, {}, null, cb)
     }, (err) => {
       if (err !== null &&
-        typeof err !=='undefined' &&
+        typeof err !== 'undefined' &&
         typeof err.badswarm.index !== 'undefined') {
         // Get swarm list
         const swarmArray = this._peerInfo.multiaddrs._multiaddrs
         // Output error in console
-        console.log(`Error connect to ${err.badswarm.address}, error type is ${err.message}, check other swarm`);
+        log(`Error connect to ${err.badswarm.address}, error type is ${err.message}, check other swarm`)
         // Delete not working swarm
         if (swarmArray.length > 0) {
           swarmArray.splice(err.badswarm.index, 1)

--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,27 @@ class Switch extends EE {
     each(this.availableTransports(this._peerInfo), (ts, cb) => {
       // Listen on the given transport
       this.transport.listen(ts, {}, null, cb)
-    }, callback)
+    }, (res) => {
+      if (res !== null &&
+        typeof res.err !=='undefined' &&
+        typeof res.index !== 'undefined') {
+        // Get swarm list
+        const swarmArray = this._peerInfo.multiaddrs._multiaddrs
+        // Output error in console
+        console.error(`Error connect to ${res.address}, error type is ${res.err.message}, check other swarm`);
+        // Delete not working swarm
+        if (swarmArray.length > 0) {
+          swarmArray.splice(res.index, 1)
+        } else {
+          throw new Error(`All swarm it's down`)
+        }
+
+        // Restart
+        return this.start(callback)
+      } else {
+        callback()
+      }
+    })
   }
 
   /**

--- a/src/limit-dialer/queue.js
+++ b/src/limit-dialer/queue.js
@@ -48,7 +48,7 @@ class DialQueue {
         log('work:cancel')
         // clean up already done dials
         pull(pull.empty(), conn)
-        // TODO: proper cleanup once the connection interface supports it
+        // This is TODO: proper cleanup once the connection interface supports it
         // return conn.close(() => callback(new Error('Manual cancel'))
         return callback(null, {cancel: true})
       }

--- a/src/transport.js
+++ b/src/transport.js
@@ -103,7 +103,7 @@ class TransportManager {
 
     let freshMultiaddrs = []
 
-    const createListeners = multiaddrs.map((ma) => {
+    const createListeners = multiaddrs.map((ma, i) => {
       return (cb) => {
         const done = once(cb)
         const listener = transport.createListener(handler)
@@ -111,7 +111,11 @@ class TransportManager {
 
         listener.listen(ma, (err) => {
           if (err) {
-            return done(err)
+            return done({
+              err: err,
+              address: ma,
+              index: i
+            })
           }
           listener.removeListener('error', done)
           listener.getAddrs((err, addrs) => {

--- a/src/transport.js
+++ b/src/transport.js
@@ -132,13 +132,8 @@ class TransportManager {
 
     parallel(createListeners, (err) => {
       if (err) {
-        const index = swarm._peerInfo.multiaddrs.toArray().indexOf(multiaddrs[0])
-
-        return callback({
-          err: err,
-          index: index,
-          address: multiaddrs[0]
-        })
+        const index = this.switch._peerInfo.multiaddrs.toArray().indexOf(multiaddrs[0])
+        return callback({ err: err, index: index, address: multiaddrs[0] })
       }
 
       // cause we can listen on port 0 or 0.0.0.0

--- a/src/transport.js
+++ b/src/transport.js
@@ -11,7 +11,7 @@ const LimitDialer = require('./limit-dialer')
 const defaultPerPeerRateLimit = 8
 
 // the amount of time a single dial has to succeed
-// TODO this should be exposed as a option
+// This is TODO this should be exposed as a option
 const dialTimeout = 30 * 1000
 
 /**

--- a/src/transport.js
+++ b/src/transport.js
@@ -132,7 +132,13 @@ class TransportManager {
 
     parallel(createListeners, (err) => {
       if (err) {
-        return callback(err)
+        const index = swarm._peerInfo.multiaddrs.toArray().indexOf(multiaddrs[0])
+
+        return callback({
+          err: err,
+          index: index,
+          address: multiaddrs[0]
+        })
       }
 
       // cause we can listen on port 0 or 0.0.0.0

--- a/src/transport.js
+++ b/src/transport.js
@@ -111,11 +111,8 @@ class TransportManager {
 
         listener.listen(ma, (err) => {
           if (err) {
-            return done({
-              err: err,
-              address: ma,
-              index: i
-            })
+            err.badswarm = { index: i, address: ma }
+            return done(err)
           }
           listener.removeListener('error', done)
           listener.getAddrs((err, addrs) => {
@@ -132,8 +129,12 @@ class TransportManager {
 
     parallel(createListeners, (err) => {
       if (err) {
-        const index = this.switch._peerInfo.multiaddrs.toArray().indexOf(multiaddrs[0])
-        return callback({ err: err, index: index, address: multiaddrs[0] })
+        err.badswarm = {
+          index: this.switch._peerInfo.multiaddrs.toArray().indexOf(multiaddrs[0]),
+          address: multiaddrs[0]
+        }
+
+        return callback(err)
       }
 
       // cause we can listen on port 0 or 0.0.0.0

--- a/test/transports.node.js
+++ b/test/transports.node.js
@@ -187,7 +187,7 @@ describe('transports', () => {
     })
 
     it('handles EADDRINUSE error when trying to listen', (done) => {
-      // TODO: fix libp2p-websockets to not throw Uncaught Error in this test
+      // This is TODO: fix libp2p-websockets to not throw Uncaught Error in this test
       if (t.n === 'WS') { return done() }
 
       const switch1 = new Switch(switchA._peerInfo, new PeerBook())


### PR DESCRIPTION
Hello, my name is Ilya Shvyryalkin. I am a developer at DCLabs (Dao Casino). When developing a messaging using ipfs-pubsub-room, we came across the following problem: I declared that I want to connect, and it's logical that if one falls off, then I need to connect to the next one, but it does not happen and the error falls out. The study of this problem led me to this module - libp2p. Fixed this issue by removing it from the pool. A few addresses that throws an error and restarts the start method. I also write the index and the address of the wrong server in the error so that it can be processed later on the client side. Tests drove out, everything works and our problem solved it. It would be very cool if you accepted these changes or wrote how you can fix this problem more elegantly.