### PR TITLE
chore: update mplex and stats test numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "aegir": "^15.1.0",
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
-    "libp2p-mplex": "~0.8.0",
+    "libp2p-mplex": "~0.8.2",
     "libp2p-pnet": "~0.1.0",
     "libp2p-secio": "~0.10.0",
     "libp2p-spdy": "~0.12.1",

--- a/test/stats.node.js
+++ b/test/stats.node.js
@@ -107,8 +107,8 @@ describe('Stats', () => {
 
       switches.forEach((swtch) => {
         let snapshot = swtch.stats.global.snapshot
-        expect(snapshot.dataReceived.toFixed()).to.equal('2426')
-        expect(snapshot.dataSent.toFixed()).to.equal('2426')
+        expect(snapshot.dataReceived.toFixed()).to.equal('2210')
+        expect(snapshot.dataSent.toFixed()).to.equal('2210')
       })
 
       teardown(switches, done)
@@ -162,8 +162,8 @@ describe('Stats', () => {
       expect(err).to.not.exist()
       switches.forEach((swtch) => {
         let snapshot = swtch.stats.forTransport('tcp').snapshot
-        expect(snapshot.dataReceived.toFixed()).to.equal('2426')
-        expect(snapshot.dataSent.toFixed()).to.equal('2426')
+        expect(snapshot.dataReceived.toFixed()).to.equal('2210')
+        expect(snapshot.dataSent.toFixed()).to.equal('2210')
       })
       teardown(switches, done)
     })
@@ -187,8 +187,8 @@ describe('Stats', () => {
       switches.forEach((swtch, index) => {
         const other = selectOther(switches, index)
         let snapshot = swtch.stats.forPeer(other._peerInfo.id.toB58String()).snapshot
-        expect(snapshot.dataReceived.toFixed()).to.equal('2426')
-        expect(snapshot.dataSent.toFixed()).to.equal('2426')
+        expect(snapshot.dataReceived.toFixed()).to.equal('2210')
+        expect(snapshot.dataSent.toFixed()).to.equal('2210')
       })
       teardown(switches, done)
     })
@@ -226,8 +226,8 @@ describe('Stats', () => {
         switches.forEach((swtch, index) => {
           const other = selectOther(switches, index)
           const snapshot = swtch.stats.forPeer(other._peerInfo.id.toB58String()).snapshot
-          expect(snapshot.dataReceived.toFixed()).to.equal('2426')
-          expect(snapshot.dataSent.toFixed()).to.equal('2426')
+          expect(snapshot.dataReceived.toFixed()).to.equal('2210')
+          expect(snapshot.dataSent.toFixed()).to.equal('2210')
         })
         teardown(switches, done)
       })
@@ -264,10 +264,10 @@ describe('Stats', () => {
           switches.forEach((swtch, index) => {
             const other = selectOther(switches, index)
             const snapshot = swtch.stats.forPeer(other._peerInfo.id.toB58String()).snapshot
-            expect(snapshot.dataReceived.toFixed()).to.equal('4852')
-            expect(snapshot.dataSent.toFixed()).to.equal('4852')
+            expect(snapshot.dataReceived.toFixed()).to.equal('4420')
+            expect(snapshot.dataSent.toFixed()).to.equal('4420')
           })
-          teardown(switches, done)
+          teardown(switches, cb)
         }
       ], done)
     })


### PR DESCRIPTION
libp2p-mplex was updated with a fix for an [edge case issue](https://github.com/libp2p/js-libp2p-mplex/pull/84) where mplex's internal _send method was potentially doing two pushes (1. the header, 2. the length prefixed data) without respecting the `readableStream.push()`'s returned value.

Those potential two pushes are now consolidated into 1 push. This reduces the total number of messages that are sent from one peer to another. As each message being sent needs to be prefixed with [some additional information](https://github.com/libp2p/mplex#message-format), reducing the number of messages sent also reduces the total byte count.

This PR updates the stats tests total byte count to match the change created by consolidating `mplex._send()` into a single push.