### PR TITLE
fix: ignore dial request when one is in progress

### DIFF
--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -145,6 +145,8 @@ class ConnectionFSM extends BaseConnection {
   dial () {
     if (this.theirB58Id === this.ourPeerInfo.id.toB58String()) {
       return this.emit('error', Errors.DIAL_SELF())
+    } else if (this.getState() === 'DIALING') {
+      return this.log('attempted to dial while already dialing, ignoring')
     }
 
     this._state('dial')

--- a/test/connection.node.js
+++ b/test/connection.node.js
@@ -137,6 +137,20 @@ describe('ConnectionFSM', () => {
     connection.dial()
   })
 
+  it('should ignore concurrent dials', () => {
+    const connection = new ConnectionFSM({
+      _switch: dialerSwitch,
+      peerInfo: listenerSwitch._peerInfo
+    })
+
+    const stub = sinon.stub(connection, '_onDialing')
+
+    connection.dial()
+    connection.dial()
+
+    expect(stub.callCount).to.equal(1)
+  })
+
   it('should be able to encrypt a basic connection', (done) => {
     const connection = new ConnectionFSM({
       _switch: dialerSwitch,


### PR DESCRIPTION
In the instance that multiple dials are requested for the same connection, this will ignore subsequent dials. In the future, we should revisit this logic for coalescing dials (a successful request with dials in the queue) and backoffs (a failure with dials in the queue). There is a limit dialer at the transport level, but we don't currently handle it at the connection level.

This issue was exposed when testing the libp2p 0.24.0-rc.1 candidate release against the js-ipfs tests.