### PR TITLE
fix: dont dial an address that we have

### DIFF
--- a/test/dialSelf.spec.js
+++ b/test/dialSelf.spec.js
@@ -7,6 +7,7 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 
+const { EventEmitter } = require('events')
 const PeerBook = require('peer-book')
 const Duplex = require('pull-pair/duplex')
 
@@ -14,8 +15,9 @@ const utils = require('./utils')
 const createInfos = utils.createInfos
 const Swarm = require('../src')
 
-class MockTransport {
+class MockTransport extends EventEmitter {
   constructor () {
+    super()
     this.conn = Duplex()
   }
   dial (addr, cb) {
@@ -34,13 +36,20 @@ class MockTransport {
 
 describe(`dial self`, () => {
   let swarmA
+  let peerInfos
 
-  before((done) => createInfos(3, (err, infos) => {
+  before((done) => createInfos(2, (err, infos) => {
     expect(err).to.not.exist()
 
-    const peerA = infos[0]
+    const peerA = infos.shift()
+    peerInfos = infos
 
     peerA.multiaddrs.add('/ip4/127.0.0.1/tcp/9001')
+    peerA.multiaddrs.add(`/ip4/127.0.0.1/tcp/9001/ipfs/${peerA.id.toB58String()}`)
+    peerA.multiaddrs.add(`/ip4/127.0.0.1/tcp/9001/p2p-circuit/ipfs/${peerA.id.toB58String()}`)
+    peerA.multiaddrs.add('/ip4/0.0.0.0/tcp/9001')
+    peerA.multiaddrs.add(`/ip4/0.0.0.0/tcp/9001/ipfs/${peerA.id.toB58String()}`)
+    peerA.multiaddrs.add(`/ip4/0.0.0.0/tcp/9001/p2p-circuit/ipfs/${peerA.id.toB58String()}`)
 
     swarmA = new Swarm(peerA, new PeerBook())
 
@@ -55,6 +64,20 @@ describe(`dial self`, () => {
     swarmA.dial(swarmA._peerInfo, (err, conn) => {
       expect(err).to.exist()
       expect(() => { throw err }).to.throw(/A node cannot dial itself/)
+      expect(conn).to.not.exist()
+      done()
+    })
+  })
+
+  it('node should not be able to dial another peers address that matches its own', (done) => {
+    const peerB = peerInfos.shift()
+    peerB.multiaddrs.add('/ip4/127.0.0.1/tcp/9001')
+    peerB.multiaddrs.add('/ip4/0.0.0.0/tcp/9001')
+    peerB.multiaddrs.add(`/ip4/0.0.0.0/tcp/9001/ipfs/${peerB.id.toB58String()}`)
+
+    swarmA.dial(peerB, (err, conn) => {
+      expect(err).to.exist()
+      expect(err.code).to.eql('CONNECTION_FAILED')
       expect(conn).to.not.exist()
       done()
     })


### PR DESCRIPTION
This PR filters out dialable addresses that match our addresses. This will help prevent us from dialing ourselves. 

This currently only handles strict equality. As we improve listen versus announce addresses, this should be improved to reflect that.

relates to https://github.com/libp2p/js-libp2p/issues/274