### PR TITLE
fix: ensure circuit listens last on start

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 const FSM = require('fsm-event')
 const EventEmitter = require('events').EventEmitter
 const each = require('async/each')
+const eachSeries = require('async/eachSeries')
 const series = require('async/series')
 const TransportManager = require('./transport')
 const ConnectionManager = require('./connection/manager')
@@ -230,7 +231,7 @@ class Switch extends EventEmitter {
    * @returns {void}
    */
   _onStarting () {
-    each(this.availableTransports(this._peerInfo), (ts, cb) => {
+    eachSeries(this.availableTransports(this._peerInfo), (ts, cb) => {
       // Listen on the given transport
       this.transport.listen(ts, {}, null, cb)
     }, (err) => {

--- a/test/circuit-relay.node.js
+++ b/test/circuit-relay.node.js
@@ -33,7 +33,7 @@ describe(`circuit`, function () {
     const peerB = infos[1]
     const peerC = infos[2]
 
-    peerA.multiaddrs.add('/ip4/127.0.0.1/tcp/9001')
+    peerA.multiaddrs.add('/ip4/0.0.0.0/tcp/9001')
     peerB.multiaddrs.add('/ip4/127.0.0.1/tcp/9002/ws')
 
     swarmA = new Swarm(peerA, new PeerBook())
@@ -85,7 +85,10 @@ describe(`circuit`, function () {
     ], (err) => {
       expect(err).to.not.exist()
       expect(swarmA._peerInfo.multiaddrs.toArray().filter((a) => a.toString()
-        .includes(`/p2p-circuit`)).length).to.equal(2)
+        .includes(`/p2p-circuit`)).length).to.equal(3)
+      // ensure swarmA has had 0.0.0.0 replaced in the addresses
+      expect(swarmA._peerInfo.multiaddrs.toArray().filter((a) => a.toString()
+        .includes(`/0.0.0.0`)).length).to.equal(0)
       expect(swarmB._peerInfo.multiaddrs.toArray().filter((a) => a.toString()
         .includes(`/p2p-circuit`)).length).to.equal(2)
       done()


### PR DESCRIPTION
Currently Switch starts all available transports listening on startup in parallel. The problem with this is that circuit should listen last. This gives the transports the opportunity to update addresses. For example, in js-ipfs, one of the default addresses in node is `/ip4/0.0.0.0/tcp/4002`.  The tcp transport will see `0.0.0.0` and bind it to available ip addresses on the network and replace it to something like `/ip4/192.168.X.X/tcp/4002`. 

Currently, the circuit address will end up looking like `/p2p-circuit/ip4/0.0.0.0/tcp/4002` instead of `/p2p-circuit/ip4/192.168.X.X/tcp/4002`, this fixes that.

I've updated a test in the circuit relay suite to verify the replacement so we avoid this in the future.

Requires #285 to resolve ci failures.