### PR TITLE
Use retimer to avoid creating so many timers

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "once": "^1.4.0",
     "peer-id": "~0.12.0",
     "peer-info": "~0.14.1",
-    "pull-stream": "^3.6.9"
+    "pull-stream": "^3.6.9",
+    "retimer": "^2.0.0"
   },
   "contributors": [
     "Alan Shaw <alan@tableflip.io>",
@@ -93,6 +94,7 @@
     "Kevin Kwok <antimatter15@gmail.com>",
     "Kobi Gurkan <kobigurk@gmail.com>",
     "Maciej Krüger <mkg20001@gmail.com>",
+    "Matteo Collina <hello@matteocollina.com>",
     "Michael Fakhry <fakhrimichael@live.com>",
     "Oli Evans <oli@tableflip.io>",
     "Pau Ramon Revilla <masylum@gmail.com>",

--- a/src/connection/manager.js
+++ b/src/connection/manager.js
@@ -85,6 +85,7 @@ class ConnectionManager {
           }
 
           conn.getPeerInfo((err, peerInfo) => {
+            /* eslint no-warning-comments: off */
             if (err) {
               return log('identify not successful')
             }
@@ -140,7 +141,7 @@ class ConnectionManager {
       encrypt = plaintext.encrypt
     }
 
-    this.switch.crypto = {tag, encrypt}
+    this.switch.crypto = { tag, encrypt }
   }
 
   /**

--- a/src/limit-dialer/queue.js
+++ b/src/limit-dialer/queue.js
@@ -42,7 +42,7 @@ class DialQueue {
     this._dialWithTimeout(transport, addr, (err, conn) => {
       if (err) {
         log.error(`${transport.constructor.name}:work`, err)
-        return callback(null, {error: err})
+        return callback(null, { error: err })
       }
 
       if (token.cancel) {
@@ -51,9 +51,9 @@ class DialQueue {
         pull(pull.empty(), conn)
         // If we can close the connection, do it
         if (typeof conn.close === 'function') {
-          return conn.close((_) => callback(null, {cancel: true}))
+          return conn.close((_) => callback(null, { cancel: true }))
         }
-        return callback(null, {cancel: true})
+        return callback(null, { cancel: true })
       }
 
       // one is enough
@@ -99,7 +99,7 @@ class DialQueue {
    * @returns {void}
    */
   push (transport, addr, token, callback) {
-    this.queue.push({transport, addr, token}, callback)
+    this.queue.push({ transport, addr, token }, callback)
   }
 }
 

--- a/src/observer.js
+++ b/src/observer.js
@@ -41,7 +41,7 @@ module.exports = (swtch) => {
     peerInfo.then((_peerInfo) => {
       if (_peerInfo) {
         const peerId = _peerInfo.id.toB58String()
-        setImmediate(() => observer.emit('message', peerId, transport, protocol, direction, bufferLength))
+        observer.emit('message', peerId, transport, protocol, direction, bufferLength)
       }
     })
   }

--- a/src/stats/stat.js
+++ b/src/stats/stat.js
@@ -3,6 +3,7 @@
 const EventEmitter = require('events')
 const Big = require('big.js').Big
 const MovingAverage = require('moving-average')
+const retimer = require('retimer')
 
 /**
  * A queue based manager for stat processing
@@ -55,7 +56,8 @@ class Stats extends EventEmitter {
    */
   stop () {
     if (this._timeout) {
-      clearTimeout(this._timeout)
+      this._timeout.clear()
+      this._timeout = null
     }
   }
 
@@ -98,9 +100,10 @@ class Stats extends EventEmitter {
    */
   _resetComputeTimeout () {
     if (this._timeout) {
-      clearTimeout(this._timeout)
+      this._timeout.reschedule(this._nextTimeout())
+    } else {
+      this._timeout = retimer(this._update, this._nextTimeout())
     }
-    this._timeout = setTimeout(this._update, this._nextTimeout())
   }
 
   /**

--- a/src/transport.js
+++ b/src/transport.js
@@ -1,5 +1,7 @@
 'use strict'
 
+/* eslint no-warning-comments: off */
+
 const parallel = require('async/parallel')
 const once = require('once')
 const debug = require('debug')

--- a/test/transports.node.js
+++ b/test/transports.node.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint no-warning-comments: off */
 'use strict'
 
 const chai = require('chai')


### PR DESCRIPTION
This PR does three things

* Use retimer to reduce the number of timers that needs to be created.
* Remove an unneeded `setImmediate`
* Fixes linting