### PR TITLE
TransportManager Refactoring to fix #300

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -38,8 +38,8 @@ function pre (done) {
       peerA.multiaddrs.add(maA)
       switchA = new Switch(peerA, new PeerBook())
 
-      switchA.transport.add('ws', new WebSockets())
-      switchA.transport.listen('ws', {}, echo, cb)
+      switchA.transportManager.add('ws', new WebSockets())
+      switchA.transportManager.listen('ws', {}, echo, cb)
     })
   }
 
@@ -53,7 +53,7 @@ function pre (done) {
       peerB.multiaddrs.add(maB)
       switchB = new Switch(peerB, new PeerBook())
 
-      switchB.transport.add('ws', new WebSockets())
+      switchB.transportManager.add('ws', new WebSockets())
       switchB.connection.addStreamMuxer(spdy)
       switchB.connection.reuse()
       switchB.handle('/echo/1.0.0', echo)
@@ -72,7 +72,7 @@ function pre (done) {
 
 function post (done) {
   parallel([
-    (cb) => switchA.transport.close('ws', cb),
+    (cb) => switchA.transportManager.close('ws', cb),
     (cb) => switchB.stop(cb),
     (cb) => sigS.stop(cb)
   ], done)

--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -196,7 +196,7 @@ class ConnectionFSM extends BaseConnection {
 
     const tKeys = this.switch.availableTransports(this.theirPeerInfo)
 
-    const circuitEnabled = Boolean(this.switch.transports[Circuit.tag])
+    const circuitEnabled = Boolean(this.switch.transport.transports[Circuit.tag])
     let circuitTried = false
 
     const nextTransport = (key) => {

--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -196,7 +196,7 @@ class ConnectionFSM extends BaseConnection {
 
     const tKeys = this.switch.availableTransports(this.theirPeerInfo)
 
-    const circuitEnabled = Boolean(this.switch.transport.transports[Circuit.tag])
+    const circuitEnabled = Boolean(this.switch.transportManager.get(Circuit.tag))
     let circuitTried = false
 
     const nextTransport = (key) => {
@@ -221,7 +221,7 @@ class ConnectionFSM extends BaseConnection {
       }
 
       this.log(`dialing transport ${transport}`)
-      this.switch.transport.dial(transport, this.theirPeerInfo, (err, _conn) => {
+      this.switch.transportManager.dial(transport, this.theirPeerInfo, (err, _conn) => {
         if (err) {
           this.emit('error:connection_attempt_failed', err.errors || [err])
           this.log(err)

--- a/src/connection/manager.js
+++ b/src/connection/manager.js
@@ -239,7 +239,7 @@ class ConnectionManager {
         Object.assign(config, { hop: { enabled: false, active: false } })
       }
 
-      this.switch.transport.add(Circuit.tag, new Circuit(this.switch, config))
+      this.switch.transportManager.add(Circuit.tag, new Circuit(this.switch, config))
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -118,10 +118,11 @@ class Switch extends EventEmitter {
    */
   availableTransports (peerInfo) {
     const myAddrs = peerInfo.multiaddrs.toArray()
-    const myTransports = Object.keys(this.transport.transports)
+    const myTransports = this.transport.getTransports()
 
     // Only listen on transports we actually have addresses for
-    return myTransports.filter((ts) => this.transport.transports[ts].filter(myAddrs).length > 0)
+    return Object.keys(myTransports)
+      .filter((ts) => myTransports[ts].filter(myAddrs).length > 0)
       // push Circuit to be the last proto to be dialed
       .sort((a) => {
         return a === 'Circuit' ? 1 : 0
@@ -181,7 +182,7 @@ class Switch extends EventEmitter {
    * @returns {boolean}
    */
   hasTransports () {
-    const transports = Object.keys(this.transport.transports).filter((t) => t !== 'Circuit')
+    const transports = Object.keys(this.transport.getTransports()).filter((t) => t !== 'Circuit')
     return transports && transports.length > 0
   }
 
@@ -241,8 +242,9 @@ class Switch extends EventEmitter {
     this.stats.stop()
     series([
       (cb) => {
-        each(this.transport.transports, (transport, cb) => {
-          each(transport.listeners, (listener, cb) => {
+        const myTransports = this.transport.getTransports()
+        each(Object.keys(myTransports), (key, cb) => {
+          each(this.transport.getListeners(key), (listener, cb) => {
             listener.close(cb)
           }, cb)
         }, cb)

--- a/src/index.js
+++ b/src/index.js
@@ -36,9 +36,6 @@ class Switch extends EventEmitter {
     this._options = options || {}
 
     this.setMaxListeners(Infinity)
-    // transports --
-    // { key: transport }; e.g { tcp: <tcp> }
-    this.transports = {}
 
     // connections --
     // { peerIdB58: { conn: <conn> }}
@@ -121,10 +118,10 @@ class Switch extends EventEmitter {
    */
   availableTransports (peerInfo) {
     const myAddrs = peerInfo.multiaddrs.toArray()
-    const myTransports = Object.keys(this.transports)
+    const myTransports = Object.keys(this.transport.transports)
 
     // Only listen on transports we actually have addresses for
-    return myTransports.filter((ts) => this.transports[ts].filter(myAddrs).length > 0)
+    return myTransports.filter((ts) => this.transport.transports[ts].filter(myAddrs).length > 0)
       // push Circuit to be the last proto to be dialed
       .sort((a) => {
         return a === 'Circuit' ? 1 : 0
@@ -184,7 +181,7 @@ class Switch extends EventEmitter {
    * @returns {boolean}
    */
   hasTransports () {
-    const transports = Object.keys(this.transports).filter((t) => t !== 'Circuit')
+    const transports = Object.keys(this.transport.transports).filter((t) => t !== 'Circuit')
     return transports && transports.length > 0
   }
 
@@ -244,7 +241,7 @@ class Switch extends EventEmitter {
     this.stats.stop()
     series([
       (cb) => {
-        each(this.transports, (transport, cb) => {
+        each(this.transport.transports, (transport, cb) => {
           each(transport.listeners, (listener, cb) => {
             listener.close(cb)
           }, cb)

--- a/src/transport.js
+++ b/src/transport.js
@@ -51,6 +51,29 @@ class TransportManager {
   }
 
   /**
+   * Returns a map of all `Transports` on the form { key: transport }; e.g { tcp: <tcp> }
+   *
+   * @returns {Map<String,Transport>}
+   */
+  getTransports () {
+    return this.transports
+  }
+
+  /**
+   * Returns an array of listeners for the `Transport` with the given key
+   *
+   * @param {String} key
+   * @returns {Array<listener>}
+   */
+  getListeners (key) {
+    if (!this.transports[key] || !this.transports[key].listeners) {
+      return []
+    } else {
+      return this.transports[key].listeners
+    }
+  }
+
+  /**
    * Closes connections for the given transport key
    * and removes it from the switch.
    *

--- a/test/circuit-relay.node.js
+++ b/test/circuit-relay.node.js
@@ -67,15 +67,15 @@ describe(`circuit`, function () {
 
   it('.enableCircuitRelay', () => {
     swarmA.connection.enableCircuitRelay({ enabled: true })
-    expect(Object.keys(swarmA.transports).length).to.equal(3)
+    expect(Object.keys(swarmA.transport.transports).length).to.equal(3)
 
     swarmB.connection.enableCircuitRelay({ enabled: true })
-    expect(Object.keys(swarmB.transports).length).to.equal(2)
+    expect(Object.keys(swarmB.transport.transports).length).to.equal(2)
   })
 
   it('listed on the transports map', () => {
-    expect(swarmA.transports.Circuit).to.exist()
-    expect(swarmB.transports.Circuit).to.exist()
+    expect(swarmA.transport.transports.Circuit).to.exist()
+    expect(swarmB.transport.transports.Circuit).to.exist()
   })
 
   it('add /p2p-circuit addrs on start', (done) => {

--- a/test/circuit-relay.node.js
+++ b/test/circuit-relay.node.js
@@ -40,11 +40,11 @@ describe(`circuit`, function () {
     swarmB = new Swarm(peerB, new PeerBook())
     swarmC = new Swarm(peerC, new PeerBook())
 
-    swarmA.transport.add('tcp', new TCP())
-    swarmA.transport.add('ws', new WS())
-    swarmB.transport.add('ws', new WS())
+    swarmA.transportManager.add('tcp', new TCP())
+    swarmA.transportManager.add('ws', new WS())
+    swarmB.transportManager.add('ws', new WS())
 
-    dialSpyA = sinon.spy(swarmA.transport, 'dial')
+    dialSpyA = sinon.spy(swarmA.transportManager, 'dial')
 
     done()
   }))
@@ -67,15 +67,15 @@ describe(`circuit`, function () {
 
   it('.enableCircuitRelay', () => {
     swarmA.connection.enableCircuitRelay({ enabled: true })
-    expect(Object.keys(swarmA.transport.transports).length).to.equal(3)
+    expect(swarmA.transportManager.getAll().size).to.equal(3)
 
     swarmB.connection.enableCircuitRelay({ enabled: true })
-    expect(Object.keys(swarmB.transport.transports).length).to.equal(2)
+    expect(swarmB.transportManager.getAll().size).to.equal(2)
   })
 
   it('listed on the transports map', () => {
-    expect(swarmA.transport.transports.Circuit).to.exist()
-    expect(swarmB.transport.transports.Circuit).to.exist()
+    expect(swarmA.transportManager.get('Circuit')).to.exist()
+    expect(swarmB.transportManager.get('Circuit')).to.exist()
   })
 
   it('add /p2p-circuit addrs on start', (done) => {
@@ -222,12 +222,12 @@ describe(`circuit`, function () {
           enabled: true
         })
 
-        bootstrapSwitch.transport.add('tcp', new TCP())
-        bootstrapSwitch.transport.add('ws', new WS())
-        tcpSwitch1.transport.add('tcp', new TCP())
-        tcpSwitch2.transport.add('tcp', new TCP())
-        wsSwitch1.transport.add('ws', new WS())
-        wsSwitch2.transport.add('ws', new WS())
+        bootstrapSwitch.transportManager.add('tcp', new TCP())
+        bootstrapSwitch.transportManager.add('ws', new WS())
+        tcpSwitch1.transportManager.add('tcp', new TCP())
+        tcpSwitch2.transportManager.add('tcp', new TCP())
+        wsSwitch1.transportManager.add('ws', new WS())
+        wsSwitch2.transportManager.add('ws', new WS())
 
         series([
           // start the nodes

--- a/test/connection.node.js
+++ b/test/connection.node.js
@@ -39,19 +39,19 @@ describe('ConnectionFSM', () => {
       dialerSwitch._peerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/15451/ws')
       dialerSwitch.connection.crypto(secio.tag, secio.encrypt)
       dialerSwitch.connection.addStreamMuxer(multiplex)
-      dialerSwitch.transport.add('ws', new WS())
+      dialerSwitch.transportManager.add('ws', new WS())
 
       listenerSwitch = new Switch(infos.shift(), new PeerBook())
       listenerSwitch._peerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/15452/ws')
       listenerSwitch.connection.crypto(secio.tag, secio.encrypt)
       listenerSwitch.connection.addStreamMuxer(multiplex)
-      listenerSwitch.transport.add('ws', new WS())
+      listenerSwitch.transportManager.add('ws', new WS())
 
       spdySwitch = new Switch(infos.shift(), new PeerBook())
       spdySwitch._peerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/15453/ws')
       spdySwitch.connection.crypto(secio.tag, secio.encrypt)
       spdySwitch.connection.addStreamMuxer(spdy)
-      spdySwitch.transport.add('ws', new WS())
+      spdySwitch.transportManager.add('ws', new WS())
 
       parallel([
         (cb) => dialerSwitch.start(cb),
@@ -132,7 +132,7 @@ describe('ConnectionFSM', () => {
       peerInfo: listenerSwitch._peerInfo
     })
 
-    const stub = sinon.stub(dialerSwitch.transport, 'dial').callsArgWith(2, {
+    const stub = sinon.stub(dialerSwitch.transportManager, 'dial').callsArgWith(2, {
       errors: [
         new Error('address in use')
       ]

--- a/test/dial-fsm.node.js
+++ b/test/dial-fsm.node.js
@@ -40,9 +40,9 @@ describe('dialFSM', () => {
     switchB = new Switch(peerB, new PeerBook())
     switchC = new Switch(peerC, new PeerBook())
 
-    switchA.transport.add('tcp', new TCP())
-    switchB.transport.add('tcp', new TCP())
-    switchC.transport.add('ws', new WS())
+    switchA.transportManager.add('tcp', new TCP())
+    switchB.transportManager.add('tcp', new TCP())
+    switchC.transportManager.add('ws', new WS())
 
     switchA.connection.crypto(secio.tag, secio.encrypt)
     switchB.connection.crypto(secio.tag, secio.encrypt)
@@ -57,9 +57,9 @@ describe('dialFSM', () => {
     switchC.connection.reuse()
 
     parallel([
-      (cb) => switchA.transport.listen('tcp', {}, null, cb),
-      (cb) => switchB.transport.listen('tcp', {}, null, cb),
-      (cb) => switchC.transport.listen('ws', {}, null, cb)
+      (cb) => switchA.transportManager.listen('tcp', {}, null, cb),
+      (cb) => switchB.transportManager.listen('tcp', {}, null, cb),
+      (cb) => switchC.transportManager.listen('ws', {}, null, cb)
     ], done)
   }))
 

--- a/test/dialSelf.spec.js
+++ b/test/dialSelf.spec.js
@@ -53,7 +53,7 @@ describe(`dial self`, () => {
 
     swarmA = new Swarm(peerA, new PeerBook())
 
-    swarmA.transport.add('tcp', new MockTransport())
+    swarmA.transportManager.add('tcp', new MockTransport())
 
     done()
   }))

--- a/test/identify.node.js
+++ b/test/identify.node.js
@@ -39,9 +39,9 @@ describe('Identify', () => {
     switchB = new Switch(peerB, new PeerBook())
     switchC = new Switch(peerC, new PeerBook())
 
-    switchA.transport.add('tcp', new TCP())
-    switchB.transport.add('tcp', new TCP())
-    switchC.transport.add('tcp', new TCP())
+    switchA.transportManager.add('tcp', new TCP())
+    switchB.transportManager.add('tcp', new TCP())
+    switchC.transportManager.add('tcp', new TCP())
 
     switchA.connection.crypto(secio.tag, secio.encrypt)
     switchB.connection.crypto(secio.tag, secio.encrypt)
@@ -56,9 +56,9 @@ describe('Identify', () => {
     switchC.connection.reuse()
 
     parallel([
-      (cb) => switchA.transport.listen('tcp', {}, null, cb),
-      (cb) => switchB.transport.listen('tcp', {}, null, cb),
-      (cb) => switchC.transport.listen('tcp', {}, null, cb)
+      (cb) => switchA.transportManager.listen('tcp', {}, null, cb),
+      (cb) => switchB.transportManager.listen('tcp', {}, null, cb),
+      (cb) => switchC.transportManager.listen('tcp', {}, null, cb)
     ], done)
   }))
 

--- a/test/pnet.node.js
+++ b/test/pnet.node.js
@@ -60,10 +60,10 @@ describe('Private Network', function () {
       protector: new Protector(psk2)
     })
 
-    switchA.transport.add('tcp', new TCP())
-    switchB.transport.add('tcp', new TCP())
-    switchC.transport.add('tcp', new TCP())
-    switchD.transport.add('tcp', new TCP())
+    switchA.transportManager.add('tcp', new TCP())
+    switchB.transportManager.add('tcp', new TCP())
+    switchC.transportManager.add('tcp', new TCP())
+    switchD.transportManager.add('tcp', new TCP())
 
     switchA.connection.crypto(secio.tag, secio.encrypt)
     switchB.connection.crypto(secio.tag, secio.encrypt)
@@ -76,10 +76,10 @@ describe('Private Network', function () {
     switchD.connection.addStreamMuxer(multiplex)
 
     parallel([
-      (cb) => switchA.transport.listen('tcp', {}, null, cb),
-      (cb) => switchB.transport.listen('tcp', {}, null, cb),
-      (cb) => switchC.transport.listen('tcp', {}, null, cb),
-      (cb) => switchD.transport.listen('tcp', {}, null, cb)
+      (cb) => switchA.transportManager.listen('tcp', {}, null, cb),
+      (cb) => switchB.transportManager.listen('tcp', {}, null, cb),
+      (cb) => switchC.transportManager.listen('tcp', {}, null, cb),
+      (cb) => switchD.transportManager.listen('tcp', {}, null, cb)
     ], done)
   }))
 

--- a/test/secio.node.js
+++ b/test/secio.node.js
@@ -37,9 +37,9 @@ describe('SECIO', () => {
     switchB = new Switch(peerB, new PeerBook())
     switchC = new Switch(peerC, new PeerBook())
 
-    switchA.transport.add('tcp', new TCP())
-    switchB.transport.add('tcp', new TCP())
-    switchC.transport.add('tcp', new TCP())
+    switchA.transportManager.add('tcp', new TCP())
+    switchB.transportManager.add('tcp', new TCP())
+    switchC.transportManager.add('tcp', new TCP())
 
     switchA.connection.crypto(secio.tag, secio.encrypt)
     switchB.connection.crypto(secio.tag, secio.encrypt)
@@ -50,9 +50,9 @@ describe('SECIO', () => {
     switchC.connection.addStreamMuxer(multiplex)
 
     parallel([
-      (cb) => switchA.transport.listen('tcp', {}, null, cb),
-      (cb) => switchB.transport.listen('tcp', {}, null, cb),
-      (cb) => switchC.transport.listen('tcp', {}, null, cb)
+      (cb) => switchA.transportManager.listen('tcp', {}, null, cb),
+      (cb) => switchB.transportManager.listen('tcp', {}, null, cb),
+      (cb) => switchC.transportManager.listen('tcp', {}, null, cb)
     ], done)
   }))
 

--- a/test/stats.node.js
+++ b/test/stats.node.js
@@ -40,8 +40,8 @@ describe('Stats', () => {
       const switchA = new Switch(peerA, new PeerBook(), options)
       const switchB = new Switch(peerB, new PeerBook(), options)
 
-      switchA.transport.add('tcp', new TCP())
-      switchB.transport.add('tcp', new TCP())
+      switchA.transportManager.add('tcp', new TCP())
+      switchB.transportManager.add('tcp', new TCP())
 
       switchA.connection.crypto(secio.tag, secio.encrypt)
       switchB.connection.crypto(secio.tag, secio.encrypt)

--- a/test/stream-muxers.node.js
+++ b/test/stream-muxers.node.js
@@ -44,14 +44,14 @@ describe('Stream Multiplexing', () => {
       switchB = new Switch(peerB, new PeerBook())
       switchC = new Switch(peerC, new PeerBook())
 
-      switchA.transport.add('tcp', new TCP())
-      switchB.transport.add('tcp', new TCP())
-      switchC.transport.add('tcp', new TCP())
+      switchA.transportManager.add('tcp', new TCP())
+      switchB.transportManager.add('tcp', new TCP())
+      switchC.transportManager.add('tcp', new TCP())
 
       parallel([
-        (cb) => switchA.transport.listen('tcp', {}, null, cb),
-        (cb) => switchB.transport.listen('tcp', {}, null, cb),
-        (cb) => switchC.transport.listen('tcp', {}, null, cb)
+        (cb) => switchA.transportManager.listen('tcp', {}, null, cb),
+        (cb) => switchB.transportManager.listen('tcp', {}, null, cb),
+        (cb) => switchC.transportManager.listen('tcp', {}, null, cb)
       ], done)
     }))
 

--- a/test/swarm-muxing+webrtc-star.browser.js
+++ b/test/swarm-muxing+webrtc-star.browser.js
@@ -55,13 +55,13 @@ describe('Switch (webrtc-star)', () => {
   it('add WebRTCStar transport to switch 1', () => {
     wstar1 = new WebRTCStar()
     switch1.transport.add('wstar', wstar1)
-    expect(Object.keys(switch1.transports).length).to.equal(1)
+    expect(Object.keys(switch1.transport.transports).length).to.equal(1)
   })
 
   it('add WebRTCStar transport to switch 2', () => {
     wstar2 = new WebRTCStar()
     switch2.transport.add('wstar', wstar2)
-    expect(Object.keys(switch2.transports).length).to.equal(1)
+    expect(Object.keys(switch2.transport.transports).length).to.equal(1)
   })
 
   it('listen on switch 1', (done) => {

--- a/test/swarm-muxing+webrtc-star.browser.js
+++ b/test/swarm-muxing+webrtc-star.browser.js
@@ -54,14 +54,14 @@ describe('Switch (webrtc-star)', () => {
 
   it('add WebRTCStar transport to switch 1', () => {
     wstar1 = new WebRTCStar()
-    switch1.transport.add('wstar', wstar1)
-    expect(Object.keys(switch1.transport.transports).length).to.equal(1)
+    switch1.transportManager.add('wstar', wstar1)
+    expect(switch1.transportManager.getAll().size).to.equal(1)
   })
 
   it('add WebRTCStar transport to switch 2', () => {
     wstar2 = new WebRTCStar()
-    switch2.transport.add('wstar', wstar2)
-    expect(Object.keys(switch2.transport.transports).length).to.equal(1)
+    switch2.transportManager.add('wstar', wstar2)
+    expect(switch2.transportManager.getAll().size).to.equal(1)
   })
 
   it('listen on switch 1', (done) => {
@@ -129,7 +129,7 @@ describe('Switch (webrtc-star)', () => {
 
       switch3 = new Switch(peer3, new PeerBook())
       const wstar3 = new WebRTCStar()
-      switch3.transport.add('wstar', wstar3)
+      switch3.transportManager.add('wstar', wstar3)
       switch3.connection.addStreamMuxer(spdy)
       switch3.connection.reuse()
       switch3.start(check)

--- a/test/swarm-muxing+websockets.browser.js
+++ b/test/swarm-muxing+websockets.browser.js
@@ -34,7 +34,7 @@ describe('Switch (WebSockets)', () => {
 
   it('add ws', () => {
     sw.transport.add('ws', new WebSockets())
-    expect(Object.keys(sw.transports).length).to.equal(1)
+    expect(Object.keys(sw.transport.transports).length).to.equal(1)
   })
 
   it('create Dst peer info', (done) => {

--- a/test/swarm-muxing+websockets.browser.js
+++ b/test/swarm-muxing+websockets.browser.js
@@ -33,8 +33,8 @@ describe('Switch (WebSockets)', () => {
   })
 
   it('add ws', () => {
-    sw.transport.add('ws', new WebSockets())
-    expect(Object.keys(sw.transport.transports).length).to.equal(1)
+    sw.transportManager.add('ws', new WebSockets())
+    expect(sw.transportManager.getAll().size).to.equal(1)
   })
 
   it('create Dst peer info', (done) => {

--- a/test/swarm-muxing.node.js
+++ b/test/swarm-muxing.node.js
@@ -59,13 +59,13 @@ describe('Switch (everything all together)', () => {
     switchB._peerInfo.multiaddrs.add('/ip4/127.0.0.1/tcp/10200')
     switchC._peerInfo.multiaddrs.add('/ip4/127.0.0.1/tcp/10300')
 
-    switchA.transport.add('tcp', new TCP())
-    switchB.transport.add('tcp', new TCP())
-    switchC.transport.add('tcp', new TCP())
+    switchA.transportManager.add('tcp', new TCP())
+    switchB.transportManager.add('tcp', new TCP())
+    switchC.transportManager.add('tcp', new TCP())
 
     parallel([
-      (cb) => switchA.transport.listen('tcp', {}, null, cb),
-      (cb) => switchB.transport.listen('tcp', {}, null, cb)
+      (cb) => switchA.transportManager.listen('tcp', {}, null, cb),
+      (cb) => switchB.transportManager.listen('tcp', {}, null, cb)
     ], done)
   })
 
@@ -75,15 +75,15 @@ describe('Switch (everything all together)', () => {
     switchD._peerInfo.multiaddrs.add('/ip4/127.0.0.1/tcp/9032/ws')
     switchE._peerInfo.multiaddrs.add('/ip4/127.0.0.1/tcp/9042/ws')
 
-    switchB.transport.add('ws', new WebSockets())
-    switchC.transport.add('ws', new WebSockets())
-    switchD.transport.add('ws', new WebSockets())
-    switchE.transport.add('ws', new WebSockets())
+    switchB.transportManager.add('ws', new WebSockets())
+    switchC.transportManager.add('ws', new WebSockets())
+    switchD.transportManager.add('ws', new WebSockets())
+    switchE.transportManager.add('ws', new WebSockets())
 
     parallel([
-      (cb) => switchB.transport.listen('ws', {}, null, cb),
-      (cb) => switchD.transport.listen('ws', {}, null, cb),
-      (cb) => switchE.transport.listen('ws', {}, null, cb)
+      (cb) => switchB.transportManager.listen('ws', {}, null, cb),
+      (cb) => switchD.transportManager.listen('ws', {}, null, cb),
+      (cb) => switchE.transportManager.listen('ws', {}, null, cb)
     ], done)
   })
 

--- a/test/swarm-no-muxing.node.js
+++ b/test/swarm-no-muxing.node.js
@@ -32,12 +32,12 @@ describe('Switch (no Stream Multiplexing)', () => {
     switchA = new Switch(peerA, new PeerBook())
     switchB = new Switch(peerB, new PeerBook())
 
-    switchA.transport.add('tcp', new TCP())
-    switchB.transport.add('tcp', new TCP())
+    switchA.transportManager.add('tcp', new TCP())
+    switchB.transportManager.add('tcp', new TCP())
 
     parallel([
-      (cb) => switchA.transport.listen('tcp', {}, null, cb),
-      (cb) => switchB.transport.listen('tcp', {}, null, cb)
+      (cb) => switchA.transportManager.listen('tcp', {}, null, cb),
+      (cb) => switchB.transportManager.listen('tcp', {}, null, cb)
     ], done)
   }))
 

--- a/test/t-webrtc-star.browser.js
+++ b/test/t-webrtc-star.browser.js
@@ -38,25 +38,25 @@ describe('transport - webrtc-star', () => {
   })
 
   it('add WebRTCStar transport to switch 1', () => {
-    switch1.transport.add('wstar', new WebRTCStar())
-    expect(Object.keys(switch1.transport.transports).length).to.equal(1)
+    switch1.transportManager.add('wstar', new WebRTCStar())
+    expect(switch1.transportManager.getAll().size).to.equal(1)
   })
 
   it('add WebRTCStar transport to switch 2', () => {
-    switch2.transport.add('wstar', new WebRTCStar())
-    expect(Object.keys(switch2.transport.transports).length).to.equal(1)
+    switch2.transportManager.add('wstar', new WebRTCStar())
+    expect(switch2.transportManager.getAll().size).to.equal(1)
   })
 
   it('listen on switch 1', (done) => {
-    switch1.transport.listen('wstar', {}, (conn) => pull(conn, conn), done)
+    switch1.transportManager.listen('wstar', {}, (conn) => pull(conn, conn), done)
   })
 
   it('listen on switch 2', (done) => {
-    switch2.transport.listen('wstar', {}, (conn) => pull(conn, conn), done)
+    switch2.transportManager.listen('wstar', {}, (conn) => pull(conn, conn), done)
   })
 
   it('dial', (done) => {
-    switch1.transport.dial('wstar', switch2._peerInfo, (err, conn) => {
+    switch1.transportManager.dial('wstar', switch2._peerInfo, (err, conn) => {
       expect(err).to.not.exist()
 
       tryEcho(conn, done)
@@ -67,7 +67,7 @@ describe('transport - webrtc-star', () => {
     peer2.multiaddrs.clear()
     peer2.multiaddrs.add('/ip4/127.0.0.1/tcp/15555/ws/p2p-webrtc-star/ipfs/ABCD')
 
-    switch1.transport.dial('wstar', peer2, (err, conn) => {
+    switch1.transportManager.dial('wstar', peer2, (err, conn) => {
       expect(err).to.exist()
       expect(conn).to.not.exist()
       done()
@@ -76,8 +76,8 @@ describe('transport - webrtc-star', () => {
 
   it('close', (done) => {
     parallel([
-      (cb) => switch1.transport.close('wstar', cb),
-      (cb) => switch2.transport.close('wstar', cb)
+      (cb) => switch1.transportManager.close('wstar', cb),
+      (cb) => switch2.transportManager.close('wstar', cb)
     ], done)
   })
 })

--- a/test/t-webrtc-star.browser.js
+++ b/test/t-webrtc-star.browser.js
@@ -39,12 +39,12 @@ describe('transport - webrtc-star', () => {
 
   it('add WebRTCStar transport to switch 1', () => {
     switch1.transport.add('wstar', new WebRTCStar())
-    expect(Object.keys(switch1.transports).length).to.equal(1)
+    expect(Object.keys(switch1.transport.transports).length).to.equal(1)
   })
 
   it('add WebRTCStar transport to switch 2', () => {
     switch2.transport.add('wstar', new WebRTCStar())
-    expect(Object.keys(switch2.transports).length).to.equal(1)
+    expect(Object.keys(switch2.transport.transports).length).to.equal(1)
   })
 
   it('listen on switch 1', (done) => {

--- a/test/transports.browser.js
+++ b/test/transports.browser.js
@@ -35,7 +35,7 @@ describe('Transports', () => {
 
     it('.transport.add', () => {
       sw.transport.add('ws', new WebSockets())
-      expect(Object.keys(sw.transports).length).to.equal(1)
+      expect(Object.keys(sw.transport.transports).length).to.equal(1)
     })
 
     it('.transport.dial', (done) => {

--- a/test/transports.browser.js
+++ b/test/transports.browser.js
@@ -34,15 +34,15 @@ describe('Transports', () => {
     })
 
     it('.transport.add', () => {
-      sw.transport.add('ws', new WebSockets())
-      expect(Object.keys(sw.transport.transports).length).to.equal(1)
+      sw.transportManager.add('ws', new WebSockets())
+      expect(sw.transportManager.getAll().size).to.equal(1)
     })
 
     it('.transport.dial', (done) => {
       peer.multiaddrs.clear()
       peer.multiaddrs.add('/ip4/127.0.0.1/tcp/15337/ws')
 
-      const conn = sw.transport.dial('ws', peer, (err, conn) => {
+      const conn = sw.transportManager.dial('ws', peer, (err, conn) => {
         expect(err).to.not.exist()
       })
 

--- a/test/transports.node.js
+++ b/test/transports.node.js
@@ -46,37 +46,39 @@ describe('transports', () => {
     })
 
     it('.transport.remove', () => {
-      switchA.transport.add('test', new t.C())
-      expect(switchA.transport.transports).to.have.any.keys(['test'])
-      switchA.transport.remove('test')
-      expect(switchA.transport.transports).to.not.have.any.keys(['test'])
+      switchA.transportManager.add('test', new t.C())
+      expect([...switchA.transportManager.getAll().keys()]).to.contain('test')
+      switchA.transportManager.remove('test')
+      expect([...switchA.transportManager.getAll().keys()]).to.not.contain('test')
       // verify remove fails silently
-      switchA.transport.remove('test')
+      switchA.transportManager.remove('test')
     })
 
     it('.transport.removeAll', (done) => {
-      switchA.transport.add('test', new t.C())
-      switchA.transport.add('test2', new t.C())
-      expect(switchA.transport.transports).to.have.any.keys(['test', 'test2'])
-      switchA.transport.removeAll(() => {
-        expect(switchA.transport.transports).to.not.have.any.keys(['test', 'test2'])
+      switchA.transportManager.add('test', new t.C())
+      switchA.transportManager.add('test2', new t.C())
+      expect([...switchA.transportManager.getAll().keys()]).to.contain('test')
+      expect([...switchA.transportManager.getAll().keys()]).to.contain('test2')
+      switchA.transportManager.removeAll(() => {
+        expect([...switchA.transportManager.getAll().keys()]).to.not.contain('test')
+        expect([...switchA.transportManager.getAll().keys()]).to.not.contain('test2')
         done()
       })
     })
 
     it('.transport.add', () => {
-      switchA.transport.add(t.n, new t.C())
-      expect(Object.keys(switchA.transport.transports).length).to.equal(1)
+      switchA.transportManager.add(t.n, new t.C())
+      expect(switchA.transportManager.getAll().size).to.equal(1)
 
-      switchB.transport.add(t.n, new t.C())
-      expect(Object.keys(switchB.transport.transports).length).to.equal(1)
+      switchB.transportManager.add(t.n, new t.C())
+      expect(switchB.transportManager.getAll().size).to.equal(1)
     })
 
     it('.transport.listen', (done) => {
       let count = 0
 
-      switchA.transport.listen(t.n, {}, (conn) => pull(conn, conn), ready)
-      switchB.transport.listen(t.n, {}, (conn) => pull(conn, conn), ready)
+      switchA.transportManager.listen(t.n, {}, (conn) => pull(conn, conn), ready)
+      switchB.transportManager.listen(t.n, {}, (conn) => pull(conn, conn), ready)
 
       function ready () {
         if (++count === 2) {
@@ -91,7 +93,7 @@ describe('transports', () => {
       const peer = morePeerInfo[0]
       peer.multiaddrs.add(t.maGen(9999))
 
-      const conn = switchA.transport.dial(t.n, peer, (err, conn) => {
+      const conn = switchA.transportManager.dial(t.n, peer, (err, conn) => {
         expect(err).to.not.exist()
       })
 
@@ -108,7 +110,7 @@ describe('transports', () => {
       // addr not supported added on purpose
       peer.multiaddrs.add('/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star')
 
-      const conn = switchA.transport.dial(t.n, peer, (err, conn) => {
+      const conn = switchA.transportManager.dial(t.n, peer, (err, conn) => {
         expect(err).to.not.exist()
       })
 
@@ -122,7 +124,7 @@ describe('transports', () => {
       // addr not supported added on purpose
       peer.multiaddrs.add('/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star')
 
-      switchA.transport.dial(t.n, peer, (err, conn) => {
+      switchA.transportManager.dial(t.n, peer, (err, conn) => {
         expect(err).to.exist()
         expect(err.errors).to.have.length(2)
         expect(conn).to.not.exist()
@@ -134,8 +136,8 @@ describe('transports', () => {
       this.timeout(2500)
 
       parallel([
-        (cb) => switchA.transport.close(t.n, cb),
-        (cb) => switchB.transport.close(t.n, cb)
+        (cb) => switchA.transportManager.close(t.n, cb),
+        (cb) => switchB.transportManager.close(t.n, cb)
       ], done)
     })
 
@@ -145,8 +147,8 @@ describe('transports', () => {
       peer.multiaddrs.add(ma)
 
       const sw = new Switch(peer, new PeerBook())
-      sw.transport.add(t.n, new t.C())
-      sw.transport.listen(t.n, {}, (conn) => pull(conn, conn), ready)
+      sw.transportManager.add(t.n, new t.C())
+      sw.transportManager.listen(t.n, {}, (conn) => pull(conn, conn), ready)
 
       function ready () {
         expect(peer.multiaddrs.size).to.equal(1)
@@ -162,8 +164,8 @@ describe('transports', () => {
       peer.multiaddrs.add(ma)
 
       const sw = new Switch(peer, new PeerBook())
-      sw.transport.add(t.n, new t.C())
-      sw.transport.listen(t.n, {}, (conn) => pull(conn, conn), ready)
+      sw.transportManager.add(t.n, new t.C())
+      sw.transportManager.listen(t.n, {}, (conn) => pull(conn, conn), ready)
 
       function ready () {
         expect(peer.multiaddrs.size >= 1).to.equal(true)
@@ -178,8 +180,8 @@ describe('transports', () => {
       peer.multiaddrs.add(ma)
 
       const sw = new Switch(peer, new PeerBook())
-      sw.transport.add(t.n, new t.C())
-      sw.transport.listen(t.n, {}, (conn) => pull(conn, conn), ready)
+      sw.transportManager.add(t.n, new t.C())
+      sw.transportManager.listen(t.n, {}, (conn) => pull(conn, conn), ready)
 
       function ready () {
         expect(peer.multiaddrs.size >= 1).to.equal(true)
@@ -197,8 +199,8 @@ describe('transports', () => {
       peer.multiaddrs.add(t.maGen(9003))
 
       const sw = new Switch(peer, new PeerBook())
-      sw.transport.add(t.n, new t.C())
-      sw.transport.listen(t.n, {}, (conn) => pull(conn, conn), ready)
+      sw.transportManager.add(t.n, new t.C())
+      sw.transportManager.listen(t.n, {}, (conn) => pull(conn, conn), ready)
 
       function ready () {
         expect(peer.multiaddrs.size).to.equal(3)
@@ -213,14 +215,14 @@ describe('transports', () => {
       const switch1 = new Switch(switchA._peerInfo, new PeerBook())
       let switch2
 
-      switch1.transport.add(t.n, new t.C())
-      switch1.transport.listen(t.n, {}, (conn) => pull(conn, conn), () => {
+      switch1.transportManager.add(t.n, new t.C())
+      switch1.transportManager.listen(t.n, {}, (conn) => pull(conn, conn), () => {
         // Add in-use (peerA) address to peerB
         switchB._peerInfo.multiaddrs.add(t.maGen(9888))
 
         switch2 = new Switch(switchB._peerInfo, new PeerBook())
-        switch2.transport.add(t.n, new t.C())
-        switch2.transport.listen(t.n, {}, (conn) => pull(conn, conn), ready)
+        switch2.transportManager.add(t.n, new t.C())
+        switch2.transportManager.listen(t.n, {}, (conn) => pull(conn, conn), ready)
       })
 
       function ready (err) {

--- a/test/transports.node.js
+++ b/test/transports.node.js
@@ -47,9 +47,9 @@ describe('transports', () => {
 
     it('.transport.remove', () => {
       switchA.transport.add('test', new t.C())
-      expect(switchA.transports).to.have.any.keys(['test'])
+      expect(switchA.transport.transports).to.have.any.keys(['test'])
       switchA.transport.remove('test')
-      expect(switchA.transports).to.not.have.any.keys(['test'])
+      expect(switchA.transport.transports).to.not.have.any.keys(['test'])
       // verify remove fails silently
       switchA.transport.remove('test')
     })
@@ -57,19 +57,19 @@ describe('transports', () => {
     it('.transport.removeAll', (done) => {
       switchA.transport.add('test', new t.C())
       switchA.transport.add('test2', new t.C())
-      expect(switchA.transports).to.have.any.keys(['test', 'test2'])
+      expect(switchA.transport.transports).to.have.any.keys(['test', 'test2'])
       switchA.transport.removeAll(() => {
-        expect(switchA.transports).to.not.have.any.keys(['test', 'test2'])
+        expect(switchA.transport.transports).to.not.have.any.keys(['test', 'test2'])
         done()
       })
     })
 
     it('.transport.add', () => {
       switchA.transport.add(t.n, new t.C())
-      expect(Object.keys(switchA.transports).length).to.equal(1)
+      expect(Object.keys(switchA.transport.transports).length).to.equal(1)
 
       switchB.transport.add(t.n, new t.C())
-      expect(Object.keys(switchB.transports).length).to.equal(1)
+      expect(Object.keys(switchB.transport.transports).length).to.equal(1)
     })
 
     it('.transport.listen', (done) => {


### PR DESCRIPTION
Encapsulates transports in TransportManager and moves the listeners outside the transport object.

One of the test in js-libp2p fails with this pull request. There is a fix for that test on this branch: https://github.com/nikor/js-libp2p/tree/js-libp2p-switch_300