### PR TITLE
fix: dial in series until we have proper abort support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,15 @@ node_js:
 os:
   - linux
   - osx
-  - windows
 
 script: npx nyc -s npm run test:node -- --bail
 after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
 
 jobs:
   include:
+    - os: windows
+      cache: false
+
     - stage: check
       script:
         - npx aegir commitlint --travis

--- a/src/limit-dialer/queue.js
+++ b/src/limit-dialer/queue.js
@@ -45,7 +45,7 @@ class DialQueue {
     this._dialWithTimeout(transport, addr, (err, conn) => {
       if (err) {
         log.error(`${transport.constructor.name}:work`, err)
-        return callback(null, { error: err })
+        return callback(err)
       }
 
       if (token.cancel) {

--- a/src/transport.js
+++ b/src/transport.js
@@ -103,9 +103,9 @@ class TransportManager {
     log('dialing %s', key, multiaddrs.map((m) => m.toString()))
 
     // dial each of the multiaddrs with the given transport
-    this.dialer.dialMany(peerInfo.id, transport, multiaddrs, (err, success) => {
-      if (err) {
-        return callback(err)
+    this.dialer.dialMany(peerInfo.id, transport, multiaddrs, (errors, success) => {
+      if (errors) {
+        return callback(errors)
       }
 
       peerInfo.connect(success.multiaddr)

--- a/test/connection.node.js
+++ b/test/connection.node.js
@@ -132,11 +132,9 @@ describe('ConnectionFSM', () => {
       peerInfo: listenerSwitch._peerInfo
     })
 
-    const stub = sinon.stub(dialerSwitch.transport, 'dial').callsArgWith(2, {
-      errors: [
-        new Error('address in use')
-      ]
-    })
+    const stub = sinon.stub(dialerSwitch.transport, 'dial').callsArgWith(2, [
+      new Error('address in use')
+    ])
 
     connection.once('error:connection_attempt_failed', (errors) => {
       expect(errors).to.have.length(1).mark()

--- a/test/limit-dialer.node.js
+++ b/test/limit-dialer.node.js
@@ -32,19 +32,18 @@ describe('LimitDialer', () => {
 
   it('all failing', (done) => {
     const dialer = new LimitDialer(2, 10)
-
+    const error = new Error('fail')
     // mock transport
     const t1 = {
       dial (addr, cb) {
-        setTimeout(() => cb(new Error('fail')), 1)
+        setTimeout(() => cb(error), 1)
         return {}
       }
     }
 
     dialer.dialMany(peers[0].id, t1, peers[0].multiaddrs.toArray(), (err, conn) => {
       expect(err).to.exist()
-      expect(err.errors).to.have.length(3)
-      expect(err.errors[0].message).to.eql('fail')
+      expect(err).to.eql([error, error, error])
       expect(conn).to.not.exist()
       done()
     })


### PR DESCRIPTION
Currently the switch will dial all addresses for a particular transport in parallel. Since we don't have any real abort support for when a dial succeeds, we should resort to dialing in serial to avoid flooding a peer with unused connections. This may result in slower dials to peers, but should also prevent flooding connections. As we improve the logic of dialing, and add proper abort support, we should be able to dial in parallel, select the best connection and abort the rest.

The first connection to succeed will be used. Circuit is already dialed last, so we don't need to worry about using Circuit if we're able to dial the node directly. 

----
This also improves the stability of the transport tests by moving `tryEcho` calls inside the dial callbacks, and adds an `after` handler to ensure the switch's are properly stopped after each transport suite is finished.