### PR TITLE
fix: identify on dial

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "libp2p-mplex": "~0.8.4",
     "libp2p-pnet": "~0.1.0",
     "libp2p-secio": "~0.11.1",
-    "libp2p-spdy": "github:libp2p/js-libp2p-spdy#fix/streams",
+    "libp2p-spdy": "~0.13.3",
     "libp2p-tcp": "~0.13.0",
     "libp2p-webrtc-star": "~0.15.8",
     "libp2p-websockets": "~0.12.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "libp2p-mplex": "~0.8.4",
     "libp2p-pnet": "~0.1.0",
     "libp2p-secio": "~0.11.1",
-    "libp2p-spdy": "~0.13.1",
+    "libp2p-spdy": "github:libp2p/js-libp2p-spdy#fix/streams",
     "libp2p-tcp": "~0.13.0",
     "libp2p-webrtc-star": "~0.15.8",
     "libp2p-websockets": "~0.12.2",

--- a/src/connection/incoming.js
+++ b/src/connection/incoming.js
@@ -54,6 +54,7 @@ class IncomingConnectionFSM extends BaseConnection {
       }
     })
 
+    this._state.on('DISCONNECTED', () => this._onDisconnected())
     this._state.on('PRIVATIZING', () => this._onPrivatizing())
     this._state.on('PRIVATIZED', () => this._onPrivatized())
     this._state.on('ENCRYPTING', () => this._onEncrypting())

--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -6,6 +6,10 @@ const multistream = require('multistream-select')
 const withIs = require('class-is')
 const BaseConnection = require('./base')
 const parallel = require('async/parallel')
+const nextTick = require('async/nextTick')
+const identify = require('libp2p-identify')
+const errCode = require('err-code')
+const { msHandle, msSelect, identifyDialer } = require('../utils')
 
 const observeConnection = require('../observe-connection')
 const {
@@ -390,10 +394,45 @@ class ConnectionFSM extends BaseConnection {
 
           this.switch.emit('peer-mux-established', this.theirPeerInfo)
           this._didUpgrade(null)
+
+          // Run identify on the connection
+          if (this.switch.identify) {
+            this._identify((err, results) => {
+              if (err) {
+                return this.close(err)
+              }
+              this.theirPeerInfo = this.switch._peerBook.put(results.peerInfo)
+            })
+          }
         })
       }
 
       nextMuxer(muxers.shift())
+    })
+  }
+
+  /**
+   * Runs the identify protocol on the connection
+   * @private
+   * @param {function(error, { PeerInfo })} callback
+   * @returns {void}
+   */
+  _identify (callback) {
+    if (!this.muxer) {
+      return nextTick(callback, errCode('The connection was already closed', 'ERR_CONNECTION_CLOSED'))
+    }
+    this.muxer.newStream(async (err, conn) => {
+      if (err) return callback(err)
+      const ms = new multistream.Dialer()
+      let results
+      try {
+        await msHandle(ms, conn)
+        const msConn = await msSelect(ms, identify.multicodec)
+        results = await identifyDialer(msConn, this.theirPeerInfo)
+      } catch (err) {
+        return callback(err)
+      }
+      callback(null, results)
     })
   }
 


### PR DESCRIPTION
Previously identify was only run by the receiver. This change is inline with how go operates.

Required by https://github.com/libp2p/js-libp2p-daemon/pull/14
- [x] Requires https://github.com/libp2p/js-libp2p-spdy/pull/86