### PR TITLE
feat: global dial queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ const sw = new switch(peerInfo , peerBook [, options])
 
 If defined, `options` should be an object with the following keys and respective values:
 
+- `blacklistTTL`: - number of ms a peer should not be dialable to after it errors. Defaults to `120000`(120 seconds)
+- `maxParallelDials` - number of concurrent dials the switch should allow. Defaults to `50`
 - `stats`: an object with the following keys and respective values:
   - `maxOldPeersRetention`: maximum old peers retention. For when peers disconnect and keeping the stats around in case they reconnect. Defaults to `100`.
   - `computeThrottleMaxQueueSize`: maximum queue size to perform stats computation throttling. Defaults to `1000`.

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = {
+  BLACK_LIST_TTL: 120e3, // How long before an errored peer can be dialed again
+  MAX_PARALLEL_DIALS: 50 // Maximum allowed concurrent dials
+}

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -74,7 +74,7 @@ module.exports = function (_switch) {
     dialFSM,
     abort,
     clearBlacklist,
-    BLACK_LIST_TTL: _switch._options.blacklistTTL || BLACK_LIST_TTL,
-    MAX_PARALLEL_DIALS: _switch._options.maxParallelDials || MAX_PARALLEL_DIALS
+    BLACK_LIST_TTL: isNaN(_switch._options.blacklistTTL) ? BLACK_LIST_TTL : _switch._options.blacklistTTL,
+    MAX_PARALLEL_DIALS: isNaN(_switch._options.maxParallelDials) ? MAX_PARALLEL_DIALS : _switch._options.maxParallelDials
   }
 }

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -2,6 +2,7 @@
 
 const DialQueueManager = require('./queueManager')
 const getPeerInfo = require('../get-peer-info')
+const { MAX_PARALLEL_DIALS, BLACK_LIST_TTL } = require('../constants')
 
 module.exports = function (_switch) {
   const dialQueueManager = new DialQueueManager(_switch)
@@ -72,6 +73,8 @@ module.exports = function (_switch) {
     dial,
     dialFSM,
     abort,
-    clearBlacklist
+    clearBlacklist,
+    BLACK_LIST_TTL: _switch._options.blacklistTTL || BLACK_LIST_TTL,
+    MAX_PARALLEL_DIALS: _switch._options.maxParallelDials || MAX_PARALLEL_DIALS
   }
 }

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -40,6 +40,14 @@ module.exports = function (_switch) {
   }
 
   /**
+   * Clears the blacklist for a given peer
+   * @param {PeerInfo} peerInfo
+   */
+  function clearBlacklist (peerInfo) {
+    dialQueueManager.clearBlacklist(peerInfo)
+  }
+
+  /**
    * Adds the dial request to the queue for the given `peerInfo`
    * @param {PeerInfo} peerInfo
    * @param {string} protocol
@@ -63,6 +71,7 @@ module.exports = function (_switch) {
   return {
     dial,
     dialFSM,
-    abort
+    abort,
+    clearBlacklist
   }
 }

--- a/src/dialer/queue.js
+++ b/src/dialer/queue.js
@@ -230,8 +230,8 @@ class Queue {
     // In the future, it may be desired to error the other queued dials,
     // depending on the error.
     connectionFSM.once('error', (err) => {
-      this.blacklist()
       queuedDial.callback(err)
+      this.blacklist()
     })
 
     connectionFSM.once('close', () => {

--- a/src/dialer/queue.js
+++ b/src/dialer/queue.js
@@ -63,6 +63,7 @@ class Queue {
    * @constructor
    * @param {string} peerId
    * @param {Switch} _switch
+   * @param {function} onStopped Called when the queue stops
    */
   constructor (peerId, _switch, onStopped) {
     this.id = peerId
@@ -94,15 +95,20 @@ class Queue {
    * Starts the queue
    */
   start () {
-    this.isRunning = true
-    this._run()
+    if (!this.isRunning) {
+      this.isRunning = true
+      this._run()
+    }
   }
 
   /**
    * Stops the queue
    */
   stop () {
-    this.isRunning = false
+    if (this.isRunning) {
+      this.isRunning = false
+      this.onStopped()
+    }
   }
 
   /**

--- a/src/dialer/queue.js
+++ b/src/dialer/queue.js
@@ -64,11 +64,12 @@ class Queue {
    * @param {string} peerId
    * @param {Switch} _switch
    */
-  constructor (peerId, _switch) {
+  constructor (peerId, _switch, onStopped) {
     this.id = peerId
     this.switch = _switch
     this._queue = []
     this.isRunning = false
+    this.onStopped = onStopped
   }
   get length () {
     return this._queue.length

--- a/src/dialer/queue.js
+++ b/src/dialer/queue.js
@@ -8,7 +8,6 @@ const once = require('once')
 const debug = require('debug')
 const log = debug('libp2p:switch:dial')
 log.error = debug('libp2p:switch:dial:error')
-const { BLACK_LIST_TTL } = require('../constants')
 
 /**
  * Components required to execute a dial
@@ -102,7 +101,7 @@ class Queue {
   isDialAllowed () {
     if (this.blackListed) {
       // If the blacklist ttl has passed, reset it
-      if (Date.now() - this.blackListed > BLACK_LIST_TTL) {
+      if (Date.now() - this.blackListed > this.switch.dialer.BLACK_LIST_TTL) {
         this.blackListed = null
         return true
       }

--- a/src/dialer/queue.js
+++ b/src/dialer/queue.js
@@ -8,8 +8,7 @@ const once = require('once')
 const debug = require('debug')
 const log = debug('libp2p:switch:dial')
 log.error = debug('libp2p:switch:dial:error')
-
-const BLACK_LIST_TTL = 60e3
+const { BLACK_LIST_TTL } = require('../constants')
 
 /**
  * Components required to execute a dial
@@ -151,6 +150,15 @@ class Queue {
   }
 
   /**
+   * Marks the queue as blacklisted. The queue will be immediately aborted.
+   */
+  blacklist () {
+    log('blacklisting queue for %s', this.id)
+    this.blackListed = Date.now()
+    this.abort()
+  }
+
+  /**
    * Attempts to find a muxed connection for the given peer. If one
    * isn't found, a new one will be created.
    *
@@ -223,8 +231,7 @@ class Queue {
     // In the future, it may be desired to error the other queued dials,
     // depending on the error.
     connectionFSM.once('error', (err) => {
-      this.blackListed = Date.now()
-      this.abort()
+      this.blacklist()
       queuedDial.callback(err)
     })
 

--- a/src/dialer/queue.js
+++ b/src/dialer/queue.js
@@ -143,11 +143,11 @@ class Queue {
    * Stops the queue and errors the callback for each dial request
    */
   abort () {
-    this.stop()
     while (this.length > 0) {
       let dial = this._queue.shift()
       dial.callback(DIAL_ABORTED())
     }
+    this.stop()
   }
 
   /**
@@ -224,7 +224,7 @@ class Queue {
     // depending on the error.
     connectionFSM.once('error', (err) => {
       this.blackListed = Date.now()
-      this.stop()
+      this.abort()
       queuedDial.callback(err)
     })
 

--- a/src/dialer/queueManager.js
+++ b/src/dialer/queueManager.js
@@ -5,8 +5,6 @@ const Queue = require('./queue')
 const { DIAL_ABORTED } = require('../errors')
 const noop = () => {}
 
-const { MAX_PARALLEL_DIALS } = require('../constants')
-
 class DialQueueManager {
   /**
    * @constructor
@@ -65,7 +63,7 @@ class DialQueueManager {
    * Will execute up to `MAX_PARALLEL_DIALS` dials
    */
   run () {
-    if (this.dials < MAX_PARALLEL_DIALS && this._queue.length > 0) {
+    if (this.dials < this.switch.dialer.MAX_PARALLEL_DIALS && this._queue.length > 0) {
       let { peerInfo, protocol, useFSM, callback } = this._queue.shift()
       let dialQueue = this.getQueue(peerInfo)
       if (dialQueue.add(protocol, useFSM, callback)) {

--- a/src/dialer/queueManager.js
+++ b/src/dialer/queueManager.js
@@ -3,8 +3,6 @@
 const once = require('once')
 const Queue = require('./queue')
 const { DIAL_ABORTED } = require('../errors')
-const debug = require('debug')
-const log = debug('libp2p:switch:dialer')
 const noop = () => {}
 
 const { MAX_PARALLEL_DIALS } = require('../constants')
@@ -19,11 +17,6 @@ class DialQueueManager {
     this._queues = {}
     this.switch = _switch
     this.dials = 0
-    this._interval = log.enabled && setInterval(() => {
-      log('%s dial queues are running', this.dials)
-      log('%s peer dial queues created', Object.keys(this._queues).length)
-      log('%s dial requests are queued', this._queue.length)
-    }, 2000)
   }
 
   /**

--- a/src/errors.js
+++ b/src/errors.js
@@ -5,6 +5,7 @@ const errCode = require('err-code')
 module.exports = {
   CONNECTION_FAILED: (err) => errCode(err, 'CONNECTION_FAILED'),
   DIAL_ABORTED: () => errCode('Dial was aborted', 'DIAL_ABORTED'),
+  ERR_BLACKLISTED: () => errCode('Dial is currently blacklisted for this peer', 'ERR_BLACKLISTED'),
   DIAL_SELF: () => errCode('A node cannot dial itself', 'DIAL_SELF'),
   INVALID_STATE_TRANSITION: (err) => errCode(err, 'INVALID_STATE_TRANSITION'),
   NO_TRANSPORTS_REGISTERED: () => errCode('No transports registered, dial not possible', 'NO_TRANSPORTS_REGISTERED'),

--- a/src/index.js
+++ b/src/index.js
@@ -110,9 +110,9 @@ class Switch extends EventEmitter {
     })
 
     // higher level (public) API
-    const dialer = getDialer(this)
-    this.dial = dialer.dial
-    this.dialFSM = dialer.dialFSM
+    this.dialer = getDialer(this)
+    this.dial = this.dialer.dial
+    this.dialFSM = this.dialer.dialFSM
   }
 
   /**

--- a/test/circuit-relay.node.js
+++ b/test/circuit-relay.node.js
@@ -19,6 +19,9 @@ const getPorts = require('portfinder').getPorts
 const utils = require('./utils')
 const createInfos = utils.createInfos
 const Swarm = require('../src')
+const switchOptions = {
+  blacklistTTL: 0 // nullifies blacklisting
+}
 
 describe(`circuit`, function () {
   let swarmA // TCP and WS
@@ -36,7 +39,7 @@ describe(`circuit`, function () {
     peerA.multiaddrs.add('/ip4/0.0.0.0/tcp/9001')
     peerB.multiaddrs.add('/ip4/127.0.0.1/tcp/9002/ws')
 
-    swarmA = new Swarm(peerA, new PeerBook())
+    swarmA = new Swarm(peerA, new PeerBook(), switchOptions)
     swarmB = new Swarm(peerB, new PeerBook())
     swarmC = new Swarm(peerC, new PeerBook())
 
@@ -61,7 +64,6 @@ describe(`circuit`, function () {
       expect(err).to.exist()
       expect(err).to.match(/Circuit not enabled and all transports failed to dial peer/)
       expect(conn).to.not.exist()
-      swarmA.dialer.clearBlacklist(swarmC._peerInfo)
       done()
     })
   })

--- a/test/circuit-relay.node.js
+++ b/test/circuit-relay.node.js
@@ -61,6 +61,7 @@ describe(`circuit`, function () {
       expect(err).to.exist()
       expect(err).to.match(/Circuit not enabled and all transports failed to dial peer/)
       expect(conn).to.not.exist()
+      swarmA.dialer.clearBlacklist(swarmC._peerInfo)
       done()
     })
   })

--- a/test/dial-fsm.node.js
+++ b/test/dial-fsm.node.js
@@ -94,6 +94,7 @@ describe('dialFSM', () => {
       connFSM.once('error:connection_attempt_failed', (errors) => {
         expect(errors).to.be.an('array')
         expect(errors).to.have.length(1)
+        switchA.dialer.clearBlacklist(switchC._peerInfo)
         done()
       })
     })

--- a/test/dial-fsm.node.js
+++ b/test/dial-fsm.node.js
@@ -114,6 +114,24 @@ describe('dialFSM', () => {
     })
   })
 
+  it('should error when the peer is blacklisted', (done) => {
+    protocol = '/error/1.0.0'
+    switchC.handle(protocol, () => { })
+
+    switchA.dialer.clearBlacklist(switchC._peerInfo)
+    switchA.dialFSM(switchC._peerInfo, protocol, (err, connFSM) => {
+      expect(err).to.not.exist()
+      connFSM.once('error', () => {
+        // dial with the blacklist
+        switchA.dialFSM(switchC._peerInfo, protocol, (err) => {
+          expect(err).to.exist()
+          expect(err.code).to.eql('ERR_BLACKLISTED')
+          done()
+        })
+      })
+    })
+  })
+
   it('should emit a `closed` event when closed', (done) => {
     protocol = '/closed/1.0.0'
     switchB.handle(protocol, () => { })

--- a/test/dial-fsm.node.js
+++ b/test/dial-fsm.node.js
@@ -94,7 +94,6 @@ describe('dialFSM', () => {
       connFSM.once('error:connection_attempt_failed', (errors) => {
         expect(errors).to.be.an('array')
         expect(errors).to.have.length(1)
-        switchA.dialer.clearBlacklist(switchC._peerInfo)
         done()
       })
     })
@@ -104,6 +103,7 @@ describe('dialFSM', () => {
     protocol = '/error/1.0.0'
     switchC.handle(protocol, () => { })
 
+    switchA.dialer.clearBlacklist(switchC._peerInfo)
     switchA.dialFSM(switchC._peerInfo, protocol, (err, connFSM) => {
       expect(err).to.not.exist()
       connFSM.once('error', (err) => {


### PR DESCRIPTION
This adds a general dial queue to the switch. All dial requests are added to the QueueManager. The QueueManager ensures no more than the maximum parallel dials requests are allowed (currently 50).

This also adds basic blacklisting with a ttl of 120 seconds. If a dial attempt errors, no dials to it will be allowed until the ttl has expired, or the blacklist has been manually cleared. Future iterations of this should add an exponential backoff for blacklisting to better manage repeat offending peers.

This alleviates issues where libp2p discovers a large number of peers, such as through the dht, and dial attempts are made to all of them. High numbers of concurrent dials lead to the cpu overloading.