### PR TITLE
fix: improve dial queue and parallel dials

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If defined, `options` should be an object with the following keys and respective
 
 - `blacklistTTL`: - number of ms a peer should not be dialable to after it errors. Defaults to `120000`(120 seconds)
 - `maxParallelDials`: - number of concurrent dials the switch should allow. Defaults to `50`
-- `dialTimeout`: - number of ms a dial to a peer should be allowed to run. Defaultd to `30000` (30 seconds)
+- `dialTimeout`: - number of ms a dial to a peer should be allowed to run. Defaults to `30000` (30 seconds)
 - `stats`: an object with the following keys and respective values:
   - `maxOldPeersRetention`: maximum old peers retention. For when peers disconnect and keeping the stats around in case they reconnect. Defaults to `100`.
   - `computeThrottleMaxQueueSize`: maximum queue size to perform stats computation throttling. Defaults to `1000`.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ const sw = new switch(peerInfo , peerBook [, options])
 If defined, `options` should be an object with the following keys and respective values:
 
 - `blacklistTTL`: - number of ms a peer should not be dialable to after it errors. Defaults to `120000`(120 seconds)
-- `maxParallelDials` - number of concurrent dials the switch should allow. Defaults to `50`
+- `maxParallelDials`: - number of concurrent dials the switch should allow. Defaults to `50`
+- `dialTimeout`: - number of ms a dial to a peer should be allowed to run. Defaultd to `30000` (30 seconds)
 - `stats`: an object with the following keys and respective values:
   - `maxOldPeersRetention`: maximum old peers retention. For when peers disconnect and keeping the stats around in case they reconnect. Defaults to `100`.
   - `computeThrottleMaxQueueSize`: maximum queue size to perform stats computation throttling. Defaults to `1000`.

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   BLACK_LIST_TTL: 120e3, // How long before an errored peer can be dialed again
+  DIAL_TIMEOUT: 30e3, // How long in ms a dial attempt is allowed to take
   MAX_PARALLEL_DIALS: 50 // Maximum allowed concurrent dials
 }

--- a/src/dialer/queue.js
+++ b/src/dialer/queue.js
@@ -63,7 +63,7 @@ class Queue {
    * @constructor
    * @param {string} peerId
    * @param {Switch} _switch
-   * @param {function} onStopped Called when the queue stops
+   * @param {function(string)} onStopped Called when the queue stops
    */
   constructor (peerId, _switch, onStopped) {
     this.id = peerId
@@ -129,7 +129,7 @@ class Queue {
     if (this.isRunning) {
       log('stopping dial queue to %s', this.id)
       this.isRunning = false
-      this.onStopped()
+      this.onStopped(this.id)
     }
   }
 

--- a/src/dialer/queue.js
+++ b/src/dialer/queue.js
@@ -78,20 +78,16 @@ class Queue {
   }
 
   /**
-   * Adds the dial request to the queue and starts the
-   * queue if it is stopped
+   * Adds the dial request to the queue. The queue is not automatically started
    * @param {string} protocol
    * @param {boolean} useFSM If callback should use a ConnectionFSM instead
    * @param {function(Error, Connection)} callback
-   * @returns {boolean} whether or not the queue has been started
    */
   add (protocol, useFSM, callback) {
     if (!this.isDialAllowed()) {
       nextTick(callback, ERR_BLACKLISTED())
-      return false
     }
     this._queue.push({ protocol, useFSM, callback })
-    return this.start()
   }
 
   /**

--- a/src/dialer/queueManager.js
+++ b/src/dialer/queueManager.js
@@ -46,6 +46,14 @@ class DialQueueManager {
     const targetQueue = this.getQueue(peerInfo)
     targetQueue.add(protocol, useFSM, callback)
 
+    // If we're already connected to the peer, start the queue now.
+    // While it might cause queues to go over the max parallel amount,
+    // it avoids blocking peers we're already connected to
+    if (peerInfo.isConnected()) {
+      targetQueue.start()
+      return
+    }
+
     // Add the id to the general queue set if the queue isn't running
     if (!targetQueue.isRunning) {
       this._queue.add(targetQueue.id)

--- a/src/limit-dialer/queue.js
+++ b/src/limit-dialer/queue.js
@@ -54,9 +54,9 @@ class DialQueue {
         pull(empty(), conn)
         // If we can close the connection, do it
         if (typeof conn.close === 'function') {
-          return conn.close((_) => callback(null, { cancel: true }))
+          return conn.close((_) => callback(null))
         }
-        return callback(null, { cancel: true })
+        return callback(null)
       }
 
       // one is enough

--- a/src/transport.js
+++ b/src/transport.js
@@ -8,12 +8,10 @@ const debug = require('debug')
 const log = debug('libp2p:switch:transport')
 
 const LimitDialer = require('./limit-dialer')
+const { DIAL_TIMEOUT } = require('./constants')
 
 // number of concurrent outbound dials to make per peer, same as go-libp2p-swtch
 const defaultPerPeerRateLimit = 8
-
-// the amount of time a single dial has to succeed
-const dialTimeout = 30 * 1000
 
 /**
  * Manages the transports for the switch. This simplifies dialing and listening across
@@ -22,7 +20,7 @@ const dialTimeout = 30 * 1000
 class TransportManager {
   constructor (_switch) {
     this.switch = _switch
-    this.dialer = new LimitDialer(defaultPerPeerRateLimit, this.switch._options.dialTimeout || dialTimeout)
+    this.dialer = new LimitDialer(defaultPerPeerRateLimit, this.switch._options.dialTimeout || DIAL_TIMEOUT)
   }
 
   /**

--- a/src/transport.js
+++ b/src/transport.js
@@ -13,7 +13,6 @@ const LimitDialer = require('./limit-dialer')
 const defaultPerPeerRateLimit = 8
 
 // the amount of time a single dial has to succeed
-// TODO this should be exposed as a option
 const dialTimeout = 30 * 1000
 
 /**
@@ -23,7 +22,7 @@ const dialTimeout = 30 * 1000
 class TransportManager {
   constructor (_switch) {
     this.switch = _switch
-    this.dialer = new LimitDialer(defaultPerPeerRateLimit, dialTimeout)
+    this.dialer = new LimitDialer(defaultPerPeerRateLimit, this.switch._options.dialTimeout || dialTimeout)
   }
 
   /**

--- a/test/limit-dialer.node.js
+++ b/test/limit-dialer.node.js
@@ -3,6 +3,7 @@
 
 const chai = require('chai')
 chai.use(require('dirty-chai'))
+chai.use(require('chai-checkmark'))
 const expect = chai.expect
 const multiaddr = require('multiaddr')
 const pull = require('pull-stream')
@@ -52,13 +53,15 @@ describe('LimitDialer', () => {
   it('two success', (done) => {
     const dialer = new LimitDialer(2, 10)
 
+    expect(2).checks(done)
+
     // mock transport
     const t1 = {
       dial (addr, cb) {
         const as = addr.toString()
         if (as.match(/191/)) {
           setImmediate(() => cb(new Error('fail')))
-          return {}
+          return null
         } else if (as.match(/192/)) {
           setTimeout(cb, 2)
           return {
@@ -69,7 +72,10 @@ describe('LimitDialer', () => {
           setTimeout(cb, 8)
           return {
             source: pull.values([2]),
-            sink: pull.drain()
+            sink: pull.onEnd((err) => {
+              // Verify the unused connection gets closed
+              expect(err).to.not.exist().mark()
+            })
           }
         }
       }
@@ -83,8 +89,7 @@ describe('LimitDialer', () => {
         conn,
         pull.collect((err, res) => {
           expect(err).to.not.exist()
-          expect(res).to.be.eql([1])
-          done()
+          expect(res).to.be.eql([1]).mark()
         })
       )
     })


### PR DESCRIPTION
## Improved Dialer
This improves the dialer queue a bit by doing a few things:

**Multidimensional queues**
As dial requests are made they no longer go into a single, global queue, they are immediately added to the dial queue for that specific peer. This allows a successful queue, or one that errors, to immediately resolve the remaining dialing requests. Previously, a subsequent request would need to wait until its turn globally, which is slow, especially if it just needs to be aborted or a new stream needs to be created for a protocol.

**Immediate dials for connected peers**
If a peer is already connected, we immediately start its queue if it's not already running. The max parallel queues aren't affected by this. This ensures that we have a steady stream of communication with our connected peers, which is critical to maintaining a healthy network.


## Configurable dial timeout
The dial timeout was also not configurable. This has been corrected and added to the readme.