### PR TITLE
feat: limit the number of cold calls we can do

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -74,7 +74,7 @@ function pre (done) {
 
 function post (done) {
   parallel([
-    (cb) => switchA.transport.close('ws', cb),
+    (cb) => switchA.stop(cb),
     (cb) => switchB.stop(cb),
     (cb) => sigS.stop(cb)
   ], done)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ const sw = new switch(peerInfo , peerBook [, options])
 
 If defined, `options` should be an object with the following keys and respective values:
 
-- `blacklistTTL`: - number of ms a peer should not be dialable to after it errors. Defaults to 5 minutes
+- `blacklistTTL`: - number of ms a peer should not be dialable to after it errors. Each successive blacklisting will increase the ttl from the base value. Defaults to 5 minutes
+- `blackListAttempts`: - number of blacklists before a peer
+is permanently blacklisted. Defaults to 5.
 - `maxParallelDials`: - number of concurrent dials the switch should allow. Defaults to `100`
 - `maxColdCalls`: - number of queued cold calls that are allowed. Defaults to `50`
 - `dialTimeout`: - number of ms a dial to a peer should be allowed to run. Defaults to `30000` (30 seconds)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ const sw = new switch(peerInfo , peerBook [, options])
 If defined, `options` should be an object with the following keys and respective values:
 
 - `blacklistTTL`: - number of ms a peer should not be dialable to after it errors. Defaults to `120000`(120 seconds)
-- `maxParallelDials`: - number of concurrent dials the switch should allow. Defaults to `50`
+- `maxParallelDials`: - number of concurrent dials the switch should allow. Defaults to `100`
+- `maxColdCalls`: - number of queued cold calls that are allowed. Defaults to `50`
 - `dialTimeout`: - number of ms a dial to a peer should be allowed to run. Defaults to `30000` (30 seconds)
 - `stats`: an object with the following keys and respective values:
   - `maxOldPeersRetention`: maximum old peers retention. For when peers disconnect and keeping the stats around in case they reconnect. Defaults to `100`.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const sw = new switch(peerInfo , peerBook [, options])
 
 If defined, `options` should be an object with the following keys and respective values:
 
-- `blacklistTTL`: - number of ms a peer should not be dialable to after it errors. Defaults to `120000`(120 seconds)
+- `blacklistTTL`: - number of ms a peer should not be dialable to after it errors. Defaults to 5 minutes
 - `maxParallelDials`: - number of concurrent dials the switch should allow. Defaults to `100`
 - `maxColdCalls`: - number of queued cold calls that are allowed. Defaults to `50`
 - `dialTimeout`: - number of ms a dial to a peer should be allowed to run. Defaults to `30000` (30 seconds)

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  BLACK_LIST_TTL: 120e3, // How long before an errored peer can be dialed again
+  BLACK_LIST_TTL: 5 * 60 * 1e3, // How long before an errored peer can be dialed again
   DIAL_TIMEOUT: 30e3, // How long in ms a dial attempt is allowed to take
   MAX_COLD_CALLS: 50, // How many dials w/o protocols that can be queued
   MAX_PARALLEL_DIALS: 100 // Maximum allowed concurrent dials

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,6 @@
 module.exports = {
   BLACK_LIST_TTL: 120e3, // How long before an errored peer can be dialed again
   DIAL_TIMEOUT: 30e3, // How long in ms a dial attempt is allowed to take
-  MAX_COLD_CALL_QUEUE: 50, // How many dials w/o protocols that can be queued
-  MAX_PARALLEL_DIALS: 50 // Maximum allowed concurrent dials
+  MAX_COLD_CALLS: 50, // How many dials w/o protocols that can be queued
+  MAX_PARALLEL_DIALS: 100 // Maximum allowed concurrent dials
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,5 +6,5 @@ module.exports = {
   DIAL_TIMEOUT: 30e3, // How long in ms a dial attempt is allowed to take
   MAX_COLD_CALLS: 50, // How many dials w/o protocols that can be queued
   MAX_PARALLEL_DIALS: 100, // Maximum allowed concurrent dials
-  ONE_HOUR: 1 * 60 * 60e3
+  QUARTER_HOUR: 15 * 60e3
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,6 @@
 module.exports = {
   BLACK_LIST_TTL: 120e3, // How long before an errored peer can be dialed again
   DIAL_TIMEOUT: 30e3, // How long in ms a dial attempt is allowed to take
-  MAX_COLD_CALL_QUEUE: 50,
+  MAX_COLD_CALL_QUEUE: 50, // How many dials w/o protocols that can be queued
   MAX_PARALLEL_DIALS: 50 // Maximum allowed concurrent dials
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   BLACK_LIST_TTL: 5 * 60 * 1e3, // How long before an errored peer can be dialed again
+  BLACK_LIST_ATTEMPTS: 5, // Num of unsuccessful dials before a peer is permanently blacklisted
   DIAL_TIMEOUT: 30e3, // How long in ms a dial attempt is allowed to take
   MAX_COLD_CALLS: 50, // How many dials w/o protocols that can be queued
   MAX_PARALLEL_DIALS: 100 // Maximum allowed concurrent dials

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,5 +3,6 @@
 module.exports = {
   BLACK_LIST_TTL: 120e3, // How long before an errored peer can be dialed again
   DIAL_TIMEOUT: 30e3, // How long in ms a dial attempt is allowed to take
+  MAX_COLD_CALL_QUEUE: 50,
   MAX_PARALLEL_DIALS: 50 // Maximum allowed concurrent dials
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,5 +5,6 @@ module.exports = {
   BLACK_LIST_ATTEMPTS: 5, // Num of unsuccessful dials before a peer is permanently blacklisted
   DIAL_TIMEOUT: 30e3, // How long in ms a dial attempt is allowed to take
   MAX_COLD_CALLS: 50, // How many dials w/o protocols that can be queued
-  MAX_PARALLEL_DIALS: 100 // Maximum allowed concurrent dials
+  MAX_PARALLEL_DIALS: 100, // Maximum allowed concurrent dials
+  ONE_HOUR: 1 * 60 * 60e3
 }

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -75,6 +75,7 @@ module.exports = function (_switch) {
     abort,
     clearBlacklist,
     BLACK_LIST_TTL: isNaN(_switch._options.blacklistTTL) ? BLACK_LIST_TTL : _switch._options.blacklistTTL,
+    MAX_COLD_CALLS: isNaN(_switch._options.maxColdCalls) ? MAX_COLD_CALLS : _switch._options.maxColdCalls,
     MAX_PARALLEL_DIALS: isNaN(_switch._options.maxParallelDials) ? MAX_PARALLEL_DIALS : _switch._options.maxParallelDials
   }
 }

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -2,7 +2,7 @@
 
 const DialQueueManager = require('./queueManager')
 const getPeerInfo = require('../get-peer-info')
-const { MAX_PARALLEL_DIALS, BLACK_LIST_TTL } = require('../constants')
+const { MAX_COLD_CALLS, MAX_PARALLEL_DIALS, BLACK_LIST_TTL } = require('../constants')
 
 module.exports = function (_switch) {
   const dialQueueManager = new DialQueueManager(_switch)

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -2,7 +2,12 @@
 
 const DialQueueManager = require('./queueManager')
 const getPeerInfo = require('../get-peer-info')
-const { MAX_COLD_CALLS, MAX_PARALLEL_DIALS, BLACK_LIST_TTL } = require('../constants')
+const {
+  BLACK_LIST_ATTEMPTS,
+  BLACK_LIST_TTL,
+  MAX_COLD_CALLS,
+  MAX_PARALLEL_DIALS
+} = require('../constants')
 
 module.exports = function (_switch) {
   const dialQueueManager = new DialQueueManager(_switch)
@@ -74,6 +79,7 @@ module.exports = function (_switch) {
     dialFSM,
     abort,
     clearBlacklist,
+    BLACK_LIST_ATTEMPTS: isNaN(_switch._options.blackListAttempts) ? BLACK_LIST_ATTEMPTS : _switch._options.blackListAttempts,
     BLACK_LIST_TTL: isNaN(_switch._options.blacklistTTL) ? BLACK_LIST_TTL : _switch._options.blacklistTTL,
     MAX_COLD_CALLS: isNaN(_switch._options.maxColdCalls) ? MAX_COLD_CALLS : _switch._options.maxColdCalls,
     MAX_PARALLEL_DIALS: isNaN(_switch._options.maxParallelDials) ? MAX_PARALLEL_DIALS : _switch._options.maxParallelDials

--- a/src/dialer/queue.js
+++ b/src/dialer/queue.js
@@ -157,7 +157,7 @@ class Queue {
       return
     }
 
-    this.blackListed = Date.now() + (this.switch.dialer.BLACK_LIST_TTL * Math.pow(this.blackListCount, 2))
+    this.blackListed = Date.now() + (this.switch.dialer.BLACK_LIST_TTL * Math.pow(this.blackListCount, 3))
     this.abort()
   }
 

--- a/src/dialer/queue.js
+++ b/src/dialer/queue.js
@@ -244,6 +244,7 @@ class Queue {
 
     // If we're not muxed yet, add listeners
     connectionFSM.once('muxed', () => {
+      this.blackListCount = 0 // reset blacklisting on good connections
       this.switch.connection.add(connectionFSM)
       queuedDial.connection = connectionFSM
       createConnectionWithProtocol(queuedDial)
@@ -251,6 +252,7 @@ class Queue {
     })
 
     connectionFSM.once('unmuxed', () => {
+      this.blackListCount = 0
       queuedDial.connection = connectionFSM
       createConnectionWithProtocol(queuedDial)
       next()

--- a/src/dialer/queueManager.js
+++ b/src/dialer/queueManager.js
@@ -109,7 +109,9 @@ class DialQueueManager {
    * @param {PeerInfo} peerInfo
    */
   clearBlacklist (peerInfo) {
-    this.getQueue(peerInfo).blackListed = null
+    const queue = this.getQueue(peerInfo)
+    queue.blackListed = null
+    queue.blackListCount = 0
   }
 
   /**

--- a/src/dialer/queueManager.js
+++ b/src/dialer/queueManager.js
@@ -71,8 +71,13 @@ class DialQueueManager {
     if (!targetQueue.isRunning) {
       if (protocol) {
         this._queue.add(targetQueue.id)
-      } else {
+        this._coldCallQueue.delete(targetQueue.id)
+      // Only add it to the cold queue if it's not in the normal queue
+      } else if (!this._queue.has(targetQueue.id)) {
         this._coldCallQueue.add(targetQueue.id)
+      // The peer is already in the normal queue, abort the cold call
+      } else {
+        return nextTick(callback, DIAL_ABORTED())
       }
     }
 

--- a/src/dialer/queueManager.js
+++ b/src/dialer/queueManager.js
@@ -48,6 +48,8 @@ class DialQueueManager {
   abort () {
     // Clear the general queue
     this._queue.clear()
+    // Clear the cold call queue
+    this._coldCallQueue.clear()
 
     this._cleanInterval.clear()
 

--- a/src/dialer/queueManager.js
+++ b/src/dialer/queueManager.js
@@ -3,6 +3,7 @@
 const once = require('once')
 const Queue = require('./queue')
 const { DIAL_ABORTED } = require('../errors')
+const { MAX_COLD_CALL_QUEUE } = require('../constants')
 const nextTick = require('async/nextTick')
 const noop = () => {}
 
@@ -48,7 +49,7 @@ class DialQueueManager {
     // Add the dial to its respective queue
     const targetQueue = this.getQueue(peerInfo)
     // If we have too many cold calls, abort the dial immediately
-    if (this._coldCallQueue.size >= this.switch.MAX_COLD_CALL_QUEUE && !protocol) {
+    if (this._coldCallQueue.size >= MAX_COLD_CALL_QUEUE && !protocol) {
       return nextTick(callback, DIAL_ABORTED())
     }
 

--- a/src/dialer/queueManager.js
+++ b/src/dialer/queueManager.js
@@ -3,7 +3,6 @@
 const once = require('once')
 const Queue = require('./queue')
 const { DIAL_ABORTED } = require('../errors')
-const { MAX_COLD_CALL_QUEUE } = require('../constants')
 const nextTick = require('async/nextTick')
 const noop = () => {}
 
@@ -38,7 +37,7 @@ class DialQueueManager {
   }
 
   /**
-   * Adds the `dialRequest` to the queue and ensures the queue is running
+   * Adds the `dialRequest` to the qMAX_COLD_CALLSe queue is running
    *
    * @param {DialRequest} dialRequest
    * @returns {void}
@@ -49,7 +48,7 @@ class DialQueueManager {
     // Add the dial to its respective queue
     const targetQueue = this.getQueue(peerInfo)
     // If we have too many cold calls, abort the dial immediately
-    if (this._coldCallQueue.size >= MAX_COLD_CALL_QUEUE && !protocol) {
+    if (this._coldCallQueue.size >= this.switch.dialer.MAX_COLD_CALLS && !protocol) {
       return nextTick(callback, DIAL_ABORTED())
     }
 

--- a/src/dialer/queueManager.js
+++ b/src/dialer/queueManager.js
@@ -37,7 +37,7 @@ class DialQueueManager {
   }
 
   /**
-   * Adds the `dialRequest` to the qMAX_COLD_CALLSe queue is running
+   * Adds the `dialRequest` to the queue and ensures queue is running
    *
    * @param {DialRequest} dialRequest
    * @returns {void}

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,6 @@ class Switch extends EventEmitter {
 
     this._peerInfo = peerInfo
     this._peerBook = peerBook
-    this._peerStore = {}
     this._options = options || {}
 
     this.setMaxListeners(Infinity)

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ class Switch extends EventEmitter {
 
     this._peerInfo = peerInfo
     this._peerBook = peerBook
+    this._peerStore = {}
     this._options = options || {}
 
     this.setMaxListeners(Infinity)

--- a/test/dialer.spec.js
+++ b/test/dialer.spec.js
@@ -1,0 +1,71 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(require('chai-checkmark'))
+chai.use(dirtyChai)
+const sinon = require('sinon')
+
+const PeerBook = require('peer-book')
+const Queue = require('../src/dialer/queue')
+const QueueManager = require('../src/dialer/queueManager')
+const Switch = require('../src')
+
+const utils = require('./utils')
+const createInfos = utils.createInfos
+
+describe('dialer', () => {
+  let switchA
+
+  before((done) => createInfos(1, (err, infos) => {
+    expect(err).to.not.exist()
+
+    switchA = new Switch(infos[0], new PeerBook())
+
+    done()
+  }))
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('queue', () => {
+    it('should blacklist forever after 5 blacklists', () => {
+      const queue = new Queue('QM', switchA)
+      for (var i = 0; i < 4; i++) {
+        queue.blacklist()
+        expect(queue.blackListed).to.be.a('number')
+        expect(queue.blackListed).to.not.eql(Infinity)
+      }
+
+      queue.blacklist()
+      expect(queue.blackListed).to.eql(Infinity)
+    })
+  })
+
+  describe('queue manager', () => {
+    let queueManager
+    before(() => {
+      queueManager = new QueueManager(switchA)
+    })
+
+    it('should abort cold calls when the queue is full', (done) => {
+      sinon.stub(queueManager._coldCallQueue, 'size').value(switchA.dialer.MAX_COLD_CALLS)
+      const dialRequest = {
+        peerInfo: {
+          id: { toB58String: () => 'QmA' }
+        },
+        protocol: null,
+        useFSM: true,
+        callback: (err) => {
+          expect(err.code).to.eql('DIAL_ABORTED')
+          done()
+        }
+      }
+
+      queueManager.add(dialRequest)
+    })
+  })
+})

--- a/test/dialer.spec.js
+++ b/test/dialer.spec.js
@@ -135,5 +135,19 @@ describe('dialer', () => {
 
       queueManager.add(dialRequest)
     })
+
+    it('should remove a queue that has reached max blacklist', () => {
+      const queue = new Queue('QmA', switchA)
+      queue.blackListed = Infinity
+
+      const abortSpy = sinon.spy(queue, 'abort')
+      const queueManager = new QueueManager(switchA)
+      queueManager._queues[queue.id] = queue
+
+      queueManager._clean()
+
+      expect(abortSpy.called).to.eql(true)
+      expect(queueManager._queues).to.eql({})
+    })
   })
 })

--- a/test/dialer.spec.js
+++ b/test/dialer.spec.js
@@ -81,12 +81,15 @@ describe('dialer', () => {
 
       const runSpy = sinon.stub(queueManager, 'run')
       const addSpy = sinon.stub(queueManager._queue, 'add')
+      const deleteSpy = sinon.stub(queueManager._coldCallQueue, 'delete')
 
       queueManager.add(dialRequest)
 
       expect(runSpy.called).to.eql(true)
       expect(addSpy.called).to.eql(true)
       expect(addSpy.getCall(0).args[0]).to.eql('QmA')
+      expect(deleteSpy.called).to.eql(true)
+      expect(deleteSpy.getCall(0).args[0]).to.eql('QmA')
     })
 
     it('should add a cold call to the cold call queue', () => {


### PR DESCRIPTION
This creates a separate queue for "cold calls" (dials without a protocol). Applications typically do this on peer discovery to connect to new peers. This is to prevent flooding the normal queue, which needs to be prioritized for normal operations, with dials to new peers that may not respond.

This is a workaround, until we can improve the peer discovery system and connection/peer tagging, to allow for proper priority. Right now all dials are treated the same, which includes just creating a new stream on an existing connection. Existing connections and new dials should not be throttled the same way. 

This also adds a very basic backoff to blacklisted peers. On its 5th blacklisting the peer will be added to the blacklist permanently. *The backoff time may need to be increased before merging this*