### PR TITLE
fix: dont blacklist good peers

### DIFF
--- a/src/dialer/queue.js
+++ b/src/dialer/queue.js
@@ -241,6 +241,10 @@ class Queue {
     // depending on the error.
     connectionFSM.once('error', (err) => {
       queuedDial.callback(err)
+      // Dont blacklist peers we have identified and that we are connected to
+      if (peerInfo.protocols.size > 0 && peerInfo.isConnected()) {
+        return
+      }
       this.blacklist()
     })
 


### PR DESCRIPTION
If a random error occurred on a good connection it would cause the peer to be blacklisted. This fixes that by avoiding the blacklisting of peers who we are currently connected to and who we've been able to negotiate `identify` with.