### PR TITLE
fix: improve stopping logic

### DIFF
--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -95,7 +95,8 @@ class ConnectionFSM extends BaseConnection {
       UPGRADING: { // Attempting to upgrade the connection with muxers
         stop: 'CONNECTED', // If we cannot mux, stop upgrading
         done: 'MUXED',
-        error: 'ERRORED'
+        error: 'ERRORED',
+        disconnect: 'DISCONNECTING'
       },
       MUXED: {
         disconnect: 'DISCONNECTING'

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -12,8 +12,6 @@ const {
 module.exports = function (_switch) {
   const dialQueueManager = new DialQueueManager(_switch)
 
-  _switch.state.on('STOPPING:enter', abort)
-
   /**
    * @param {DialRequest} dialRequest
    * @returns {void}

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -12,6 +12,9 @@ const {
 module.exports = function (_switch) {
   const dialQueueManager = new DialQueueManager(_switch)
 
+  _switch.state.on('STARTED:enter', start)
+  _switch.state.on('STOPPING:enter', stop)
+
   /**
    * @param {DialRequest} dialRequest
    * @returns {void}
@@ -33,13 +36,23 @@ module.exports = function (_switch) {
   }
 
   /**
+   * Starts the `DialQueueManager`
+   *
+   * @param {function} callback
+   */
+  function start (callback) {
+    dialQueueManager.start()
+    callback()
+  }
+
+  /**
    * Aborts all dials that are queued. This should
    * only be used when the Switch is being stopped
    *
    * @param {function} callback
    */
-  function abort (callback) {
-    dialQueueManager.abort()
+  function stop (callback) {
+    dialQueueManager.stop()
     callback()
   }
 
@@ -75,7 +88,6 @@ module.exports = function (_switch) {
   return {
     dial,
     dialFSM,
-    abort,
     clearBlacklist,
     BLACK_LIST_ATTEMPTS: isNaN(_switch._options.blackListAttempts) ? BLACK_LIST_ATTEMPTS : _switch._options.blackListAttempts,
     BLACK_LIST_TTL: isNaN(_switch._options.blacklistTTL) ? BLACK_LIST_TTL : _switch._options.blacklistTTL,

--- a/src/dialer/queueManager.js
+++ b/src/dialer/queueManager.js
@@ -22,6 +22,7 @@ class DialQueueManager {
     this._queues = {}
     this.switch = _switch
     this._cleanInterval = retimer(this._clean.bind(this), QUARTER_HOUR)
+    this.start()
   }
 
   /**
@@ -67,12 +68,20 @@ class DialQueueManager {
   }
 
   /**
+   * Allows the `DialQueueManager` to execute dials
+   */
+  start () {
+    this.isRunning = true
+  }
+
+  /**
    * Iterates over all items in the DialerQueue
    * and executes there callback with an error.
    *
    * This causes the entire DialerQueue to be drained
    */
-  abort () {
+  stop () {
+    this.isRunning = false
     // Clear the general queue
     this._queue.clear()
     // Clear the cold call queue
@@ -140,6 +149,8 @@ class DialQueueManager {
    * Will execute up to `MAX_PARALLEL_DIALS` dials
    */
   run () {
+    if (!this.isRunning) return
+
     if (this._dialingQueues.size < this.switch.dialer.MAX_PARALLEL_DIALS) {
       let nextQueue = { done: true }
       // Check the queue first and fall back to the cold call queue

--- a/src/index.js
+++ b/src/index.js
@@ -258,8 +258,7 @@ class Switch extends EventEmitter {
           }, cb)
         }, cb)
       },
-      (cb) =>
-        each(this.connection.getAll(), (conn, cb) => {
+      (cb) => each(this.connection.getAll(), (conn, cb) => {
         conn.once('close', cb)
         conn.close()
       }, cb)

--- a/src/index.js
+++ b/src/index.js
@@ -254,6 +254,7 @@ class Switch extends EventEmitter {
           }, cb)
         }, cb)
       },
+      (cb) => this.dialer.abort(cb),
       (cb) => each(this.connection.getAll(), (conn, cb) => {
         conn.once('close', cb)
         conn.close()

--- a/src/index.js
+++ b/src/index.js
@@ -232,7 +232,8 @@ class Switch extends EventEmitter {
     }, (err) => {
       if (err) {
         log.error(err)
-        return this.emit('error', err)
+        this.emit('error', err)
+        return this.state('stop')
       }
       this.state('done')
     })
@@ -250,12 +251,15 @@ class Switch extends EventEmitter {
       (cb) => {
         each(this.transports, (transport, cb) => {
           each(transport.listeners, (listener, cb) => {
-            listener.close(cb)
+            listener.close((err) => {
+              if (err) log.error(err)
+              cb()
+            })
           }, cb)
         }, cb)
       },
-      (cb) => this.dialer.abort(cb),
-      (cb) => each(this.connection.getAll(), (conn, cb) => {
+      (cb) =>
+        each(this.connection.getAll(), (conn, cb) => {
         conn.once('close', cb)
         conn.close()
       }, cb)

--- a/test/circuit-relay.node.js
+++ b/test/circuit-relay.node.js
@@ -24,124 +24,126 @@ const switchOptions = {
 }
 
 describe(`circuit`, function () {
-  let swarmA // TCP and WS
-  let swarmB // WS
-  let swarmC // no transports
-  let dialSpyA
+  describe('basic', () => {
+    let swarmA // TCP and WS
+    let swarmB // WS
+    let swarmC // no transports
+    let dialSpyA
 
-  before((done) => createInfos(3, (err, infos) => {
-    expect(err).to.not.exist()
-
-    const peerA = infos[0]
-    const peerB = infos[1]
-    const peerC = infos[2]
-
-    peerA.multiaddrs.add('/ip4/0.0.0.0/tcp/9001')
-    peerB.multiaddrs.add('/ip4/127.0.0.1/tcp/9002/ws')
-
-    swarmA = new Swarm(peerA, new PeerBook(), switchOptions)
-    swarmB = new Swarm(peerB, new PeerBook())
-    swarmC = new Swarm(peerC, new PeerBook())
-
-    swarmA.transport.add('tcp', new TCP())
-    swarmA.transport.add('ws', new WS())
-    swarmB.transport.add('ws', new WS())
-
-    dialSpyA = sinon.spy(swarmA.transport, 'dial')
-
-    done()
-  }))
-
-  after((done) => {
-    parallel([
-      (cb) => swarmA.stop(cb),
-      (cb) => swarmB.stop(cb)
-    ], done)
-  })
-
-  it('circuit not enabled and all transports failed', (done) => {
-    swarmA.dial(swarmC._peerInfo, (err, conn) => {
-      expect(err).to.exist()
-      expect(err).to.match(/Circuit not enabled and all transports failed to dial peer/)
-      expect(conn).to.not.exist()
-      done()
-    })
-  })
-
-  it('.enableCircuitRelay', () => {
-    swarmA.connection.enableCircuitRelay({ enabled: true })
-    expect(Object.keys(swarmA.transports).length).to.equal(3)
-
-    swarmB.connection.enableCircuitRelay({ enabled: true })
-    expect(Object.keys(swarmB.transports).length).to.equal(2)
-  })
-
-  it('listed on the transports map', () => {
-    expect(swarmA.transports.Circuit).to.exist()
-    expect(swarmB.transports.Circuit).to.exist()
-  })
-
-  it('add /p2p-circuit addrs on start', (done) => {
-    parallel([
-      (cb) => swarmA.start(cb),
-      (cb) => swarmB.start(cb)
-    ], (err) => {
+    before((done) => createInfos(3, (err, infos) => {
       expect(err).to.not.exist()
-      expect(swarmA._peerInfo.multiaddrs.toArray().filter((a) => a.toString()
-        .includes(`/p2p-circuit`)).length).to.be.at.least(3)
-      // ensure swarmA has had 0.0.0.0 replaced in the addresses
-      expect(swarmA._peerInfo.multiaddrs.toArray().filter((a) => a.toString()
-        .includes(`/0.0.0.0`)).length).to.equal(0)
-      expect(swarmB._peerInfo.multiaddrs.toArray().filter((a) => a.toString()
-        .includes(`/p2p-circuit`)).length).to.be.at.least(2)
+
+      const peerA = infos[0]
+      const peerB = infos[1]
+      const peerC = infos[2]
+
+      peerA.multiaddrs.add('/ip4/0.0.0.0/tcp/9001')
+      peerB.multiaddrs.add('/ip4/127.0.0.1/tcp/9002/ws')
+
+      swarmA = new Swarm(peerA, new PeerBook(), switchOptions)
+      swarmB = new Swarm(peerB, new PeerBook())
+      swarmC = new Swarm(peerC, new PeerBook())
+
+      swarmA.transport.add('tcp', new TCP())
+      swarmA.transport.add('ws', new WS())
+      swarmB.transport.add('ws', new WS())
+
+      dialSpyA = sinon.spy(swarmA.transport, 'dial')
+
       done()
+    }))
+
+    after((done) => {
+      parallel([
+        (cb) => swarmA.stop(cb),
+        (cb) => swarmB.stop(cb)
+      ], done)
     })
-  })
 
-  it('dial circuit only once', (done) => {
-    swarmA._peerInfo.multiaddrs.clear()
-    swarmA._peerInfo.multiaddrs
-      .add(`/dns4/wrtc-star.discovery.libp2p.io/tcp/443/wss/p2p-webrtc-star`)
-
-    swarmA.dial(swarmC._peerInfo, (err, conn) => {
-      expect(err).to.exist()
-      expect(err).to.match(/No available transports to dial peer/)
-      expect(conn).to.not.exist()
-      expect(dialSpyA.callCount).to.be.eql(1)
-      done()
+    it('circuit not enabled and all transports failed', (done) => {
+      swarmA.dial(swarmC._peerInfo, (err, conn) => {
+        expect(err).to.exist()
+        expect(err).to.match(/Circuit not enabled and all transports failed to dial peer/)
+        expect(conn).to.not.exist()
+        done()
+      })
     })
-  })
 
-  it('dial circuit last', (done) => {
-    const peerC = swarmC._peerInfo
-    peerC.multiaddrs.clear()
-    peerC.multiaddrs.add(`/p2p-circuit/ipfs/ABCD`)
-    peerC.multiaddrs.add(`/ip4/127.0.0.1/tcp/9998/ipfs/ABCD`)
-    peerC.multiaddrs.add(`/ip4/127.0.0.1/tcp/9999/ws/ipfs/ABCD`)
+    it('.enableCircuitRelay', () => {
+      swarmA.connection.enableCircuitRelay({ enabled: true })
+      expect(Object.keys(swarmA.transports).length).to.equal(3)
 
-    swarmA.dial(peerC, (err, conn) => {
-      expect(err).to.exist()
-      expect(conn).to.not.exist()
-      expect(dialSpyA.lastCall.args[0]).to.be.eql('Circuit')
-      done()
+      swarmB.connection.enableCircuitRelay({ enabled: true })
+      expect(Object.keys(swarmB.transports).length).to.equal(2)
     })
-  })
 
-  it('should not try circuit if no transports enabled', (done) => {
-    swarmC.dial(swarmA._peerInfo, (err, conn) => {
-      expect(err).to.exist()
-      expect(conn).to.not.exist()
-
-      expect(err).to.match(/No transports registered, dial not possible/)
-      done()
+    it('listed on the transports map', () => {
+      expect(swarmA.transports.Circuit).to.exist()
+      expect(swarmB.transports.Circuit).to.exist()
     })
-  })
 
-  it('should not dial circuit if other transport succeed', (done) => {
-    swarmA.dial(swarmB._peerInfo, (err) => {
-      expect(err).not.to.exist()
-      expect(dialSpyA.lastCall.args[0]).to.not.be.eql('Circuit')
-      done()
+    it('add /p2p-circuit addrs on start', (done) => {
+      parallel([
+        (cb) => swarmA.start(cb),
+        (cb) => swarmB.start(cb)
+      ], (err) => {
+        expect(err).to.not.exist()
+        expect(swarmA._peerInfo.multiaddrs.toArray().filter((a) => a.toString()
+          .includes(`/p2p-circuit`)).length).to.be.at.least(3)
+        // ensure swarmA has had 0.0.0.0 replaced in the addresses
+        expect(swarmA._peerInfo.multiaddrs.toArray().filter((a) => a.toString()
+          .includes(`/0.0.0.0`)).length).to.equal(0)
+        expect(swarmB._peerInfo.multiaddrs.toArray().filter((a) => a.toString()
+          .includes(`/p2p-circuit`)).length).to.be.at.least(2)
+        done()
+      })
+    })
+
+    it('dial circuit only once', (done) => {
+      swarmA._peerInfo.multiaddrs.clear()
+      swarmA._peerInfo.multiaddrs
+        .add(`/dns4/wrtc-star.discovery.libp2p.io/tcp/443/wss/p2p-webrtc-star`)
+
+      swarmA.dial(swarmC._peerInfo, (err, conn) => {
+        expect(err).to.exist()
+        expect(err).to.match(/No available transports to dial peer/)
+        expect(conn).to.not.exist()
+        expect(dialSpyA.callCount).to.be.eql(1)
+        done()
+      })
+    })
+
+    it('dial circuit last', (done) => {
+      const peerC = swarmC._peerInfo
+      peerC.multiaddrs.clear()
+      peerC.multiaddrs.add(`/p2p-circuit/ipfs/ABCD`)
+      peerC.multiaddrs.add(`/ip4/127.0.0.1/tcp/9998/ipfs/ABCD`)
+      peerC.multiaddrs.add(`/ip4/127.0.0.1/tcp/9999/ws/ipfs/ABCD`)
+
+      swarmA.dial(peerC, (err, conn) => {
+        expect(err).to.exist()
+        expect(conn).to.not.exist()
+        expect(dialSpyA.lastCall.args[0]).to.be.eql('Circuit')
+        done()
+      })
+    })
+
+    it('should not try circuit if no transports enabled', (done) => {
+      swarmC.dial(swarmA._peerInfo, (err, conn) => {
+        expect(err).to.exist()
+        expect(conn).to.not.exist()
+
+        expect(err).to.match(/No transports registered, dial not possible/)
+        done()
+      })
+    })
+
+    it('should not dial circuit if other transport succeed', (done) => {
+      swarmA.dial(swarmB._peerInfo, (err) => {
+        expect(err).not.to.exist()
+        expect(dialSpyA.lastCall.args[0]).to.not.be.eql('Circuit')
+        done()
+      })
     })
   })
 


### PR DESCRIPTION
This includes code from https://github.com/libp2p/js-libp2p-switch/pull/322 and builds off of it to fix some other stopping issues.

1. Connections weren't allowing disconnect when upgrading. So if a close was attempted while muxing was being negotiated the connection wouldn't close. I updated an existing test to better catch this.
2. When stopping, if a listener errors during close it would cause stopping to fail. This change logs the error out and continues on with stopping the switch to ensure all connections are terminated.

Also, if starting errored it would only log the error out and not stop the switch, this corrects that.