### PR TITLE
feat: support a priority queue for dials

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,11 @@ and to received the underlying connection that can be used to transfer data.
 
 ### `switch.dialer.connect(peer, options, callback)`
 
-a low priority dial to the provided peer. Calls to `dial` and `dialFSM` will take priority. This should be used when
-an application only wishes to establish connections to new peers, such as during peer discovery when there is a low
-peer count.
+a low priority dial to the provided peer. Calls to `dial` and `dialFSM` will take priority. This should be used when an application only wishes to establish connections to new peers, such as during peer discovery when there is a low peer count. Currently, anything greater than the HIGH_PRIORITY (10) will be placed into the cold call queue, and anything less than or equal to the HIGH_PRIORITY will be added to the normal queue.
 
 - `peer`: can be an instance of [PeerInfo][], [PeerId][] or [multiaddr][]
 - `options`: Optional
-- `options.priority`: Number of the priority of the dial, defaults to 1.
+- `options.priority`: Number of the priority of the dial, defaults to 20.
 - `options.useFSM`: Boolean of whether or not to callback with a [Connection State Machine](#connection-state-machine)
 - `callback`: Function with signature `function (err, connFSM) {}` where `connFSM` is a [Connection State Machine](#connection-state-machine)
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,18 @@ works like dial, but calls back with a [Connection State Machine](#connection-st
 Connection state machines emit a number of events that can be used to determine the current state of the connection
 and to received the underlying connection that can be used to transfer data.
 
+### `switch.dialer.connect(peer, options, callback)`
+
+a low priority dial to the provided peer. Calls to `dial` and `dialFSM` will take priority. This should be used when
+an application only wishes to establish connections to new peers, such as during peer discovery when there is a low
+peer count.
+
+- `peer`: can be an instance of [PeerInfo][], [PeerId][] or [multiaddr][]
+- `options`: Optional
+- `options.priority`: Number of the priority of the dial, defaults to 1.
+- `options.useFSM`: Boolean of whether or not to callback with a [Connection State Machine](#connection-state-machine)
+- `callback`: Function with signature `function (err, connFSM) {}` where `connFSM` is a [Connection State Machine](#connection-state-machine)
+
 ##### Events
 - `error`:  emitted whenever a fatal error occurs with the connection; the error will be emitted.
 - `error:upgrade_failed`: emitted whenever the connection fails to upgrade with a muxer, this is not fatal.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,17 @@ Emitted when the switch encounters an error.
 
 ### `switch.on('peer-mux-closed', (peer) => {})`
 
-- `peer`: is instance of [PeerInfo][] that has info of the peer we have just closed a muxed connection.
+- `peer`: is instance of [PeerInfo][] that has info of the peer we have just closed a muxed connection with.
+
+### `switch.on('connection:start', (peer) => {})`
+This will be triggered anytime a new connection is created.
+
+- `peer`: is instance of [PeerInfo][] that has info of the peer we have just started a connection with.
+
+### `switch.on('connection:end', (peer) => {})`
+This will be triggered anytime an existing connection, regardless of state, is removed from the switch's internal connection tracking.
+
+- `peer`: is instance of [PeerInfo][] that has info of the peer we have just closed a connection with.
 
 ### `switch.on('start', () => {})`
 

--- a/src/connection/base.js
+++ b/src/connection/base.js
@@ -80,6 +80,7 @@ class BaseConnection extends EventEmitter {
    * @returns {void}
    */
   _onDisconnected () {
+    this.switch.connection.remove(this)
     this.log('disconnected from %s', this.theirB58Id)
     this.emit('close')
     this.removeAllListeners()

--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -269,8 +269,6 @@ class ConnectionFSM extends BaseConnection {
   _onDisconnecting () {
     this.log('disconnecting from %s', this.theirB58Id, Boolean(this.muxer))
 
-    this.switch.connection.remove(this)
-
     delete this.switch.conns[this.theirB58Id]
 
     let tasks = []

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,5 +6,7 @@ module.exports = {
   DIAL_TIMEOUT: 30e3, // How long in ms a dial attempt is allowed to take
   MAX_COLD_CALLS: 50, // How many dials w/o protocols that can be queued
   MAX_PARALLEL_DIALS: 100, // Maximum allowed concurrent dials
-  QUARTER_HOUR: 15 * 60e3
+  QUARTER_HOUR: 15 * 60e3,
+  PRIORITY_HIGH: 10,
+  PRIORITY_LOW: 20
 }

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -72,7 +72,7 @@ module.exports = function (_switch) {
    * @param {PeerInfo} peerInfo
    * @param {object} options
    * @param {boolean} options.useFSM Whether or not to return a `ConnectionFSM`. Defaults to false.
-   * @param {number} options.priority Lowest priority goes first. Defaults to 1.
+   * @param {number} options.priority Lowest priority goes first. Defaults to 20.
    * @param {function(Error, Connection)} callback
    */
   function connect (peerInfo, options, callback) {
@@ -86,6 +86,7 @@ module.exports = function (_switch) {
 
   /**
    * Adds the dial request to the queue for the given `peerInfo`
+   * The request will be added with a high priority (10).
    * @param {PeerInfo} peerInfo
    * @param {string} protocol
    * @param {function(Error, Connection)} callback

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -74,6 +74,10 @@ module.exports = function (_switch) {
    * @param {function(Error, Connection)} callback
    */
   function connect (peerInfo, options, callback) {
+    if (typeof options === 'function') {
+      callback = options
+      options = null
+    }
     options = { useFSM: false, priority: 1, ...options }
     _dial({ peerInfo, protocol: null, options, callback })
   }

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -6,7 +6,9 @@ const {
   BLACK_LIST_ATTEMPTS,
   BLACK_LIST_TTL,
   MAX_COLD_CALLS,
-  MAX_PARALLEL_DIALS
+  MAX_PARALLEL_DIALS,
+  PRIORITY_HIGH,
+  PRIORITY_LOW
 } = require('../constants')
 
 module.exports = function (_switch) {
@@ -78,7 +80,7 @@ module.exports = function (_switch) {
       callback = options
       options = null
     }
-    options = { useFSM: false, priority: 1, ...options }
+    options = { useFSM: false, priority: PRIORITY_LOW, ...options }
     _dial({ peerInfo, protocol: null, options, callback })
   }
 
@@ -89,7 +91,7 @@ module.exports = function (_switch) {
    * @param {function(Error, Connection)} callback
    */
   function dial (peerInfo, protocol, callback) {
-    _dial({ peerInfo, protocol, options: { useFSM: false, priority: 0 }, callback })
+    _dial({ peerInfo, protocol, options: { useFSM: false, priority: PRIORITY_HIGH }, callback })
   }
 
   /**
@@ -100,7 +102,7 @@ module.exports = function (_switch) {
    * @param {function(Error, ConnectionFSM)} callback
    */
   function dialFSM (peerInfo, protocol, callback) {
-    _dial({ peerInfo, protocol, options: { useFSM: true, priority: 0 }, callback })
+    _dial({ peerInfo, protocol, options: { useFSM: true, priority: PRIORITY_HIGH }, callback })
   }
 
   return {

--- a/src/dialer/queue.js
+++ b/src/dialer/queue.js
@@ -13,7 +13,9 @@ log.error = debug('libp2p:switch:dial:error')
  * @typedef {Object} DialRequest
  * @property {PeerInfo} peerInfo - The peer to dial to
  * @property {string} [protocol] - The protocol to create a stream for
- * @property {boolean} useFSM - If `callback` should return a ConnectionFSM
+ * @property {object} options
+ * @property {boolean} options.useFSM - If `callback` should return a ConnectionFSM
+ * @property {number} options.priority - The priority of the dial
  * @property {function(Error, Connection|ConnectionFSM)} callback
  */
 

--- a/src/dialer/queueManager.js
+++ b/src/dialer/queueManager.js
@@ -5,7 +5,7 @@ const Queue = require('./queue')
 const { DIAL_ABORTED } = require('../errors')
 const nextTick = require('async/nextTick')
 const retimer = require('retimer')
-const { QUARTER_HOUR } = require('../constants')
+const { QUARTER_HOUR, PRIORITY_HIGH } = require('../constants')
 const debug = require('debug')
 const log = debug('libp2p:switch:dial:manager')
 const noop = () => {}
@@ -110,7 +110,7 @@ class DialQueueManager {
     const targetQueue = this.getQueue(peerInfo)
 
     // Cold Call
-    if (options.priority > 0) {
+    if (options.priority > PRIORITY_HIGH) {
       // If we have too many cold calls, abort the dial immediately
       if (this._coldCallQueue.size >= this.switch.dialer.MAX_COLD_CALLS) {
         return nextTick(callback, DIAL_ABORTED())
@@ -138,7 +138,7 @@ class DialQueueManager {
 
     // Add the id to its respective queue set if the queue isn't running
     if (!targetQueue.isRunning) {
-      if (options.priority === 0) {
+      if (options.priority <= PRIORITY_HIGH) {
         this._queue.add(targetQueue.id)
         this._coldCallQueue.delete(targetQueue.id)
       // Only add it to the cold queue if it's not in the normal queue

--- a/src/dialer/queueManager.js
+++ b/src/dialer/queueManager.js
@@ -21,15 +21,6 @@ class DialQueueManager {
     this._dialingQueues = new Set()
     this._queues = {}
     this.switch = _switch
-
-    setInterval(() => {
-      console.log('Cold queue has %s items', this._coldCallQueue.size)
-      console.log('Normal queue has %s items', this._queue.size)
-      console.log('Currently dialing to %s queues', this._dialingQueues.size)
-      console.log('%s items in the queue', Object.keys(this._dialingQueues.size).length)
-      console.log('%s connections', this.switch.connection.getAll().length)
-      console.log('%s known peers', Object.keys(this.switch._peerBook.getAll()).length)
-    }, 5e3)
     this._cleanInterval = retimer(this._clean.bind(this), QUARTER_HOUR)
     this.start()
   }

--- a/test/dialer.spec.js
+++ b/test/dialer.spec.js
@@ -12,6 +12,7 @@ const PeerBook = require('peer-book')
 const Queue = require('../src/dialer/queue')
 const QueueManager = require('../src/dialer/queueManager')
 const Switch = require('../src')
+const { PRIORITY_HIGH, PRIORITY_LOW } = require('../src/constants')
 
 const utils = require('./utils')
 const createInfos = utils.createInfos
@@ -46,7 +47,7 @@ describe('dialer', () => {
     })
 
     it('should be able to use custom options', (done) => {
-      switchA.dialer.connect(switchB._peerInfo, { useFSM: true, priority: 0 }, (err) => {
+      switchA.dialer.connect(switchB._peerInfo, { useFSM: true, priority: PRIORITY_HIGH }, (err) => {
         expect(err).to.exist()
         done()
       })
@@ -80,7 +81,7 @@ describe('dialer', () => {
           id: { toB58String: () => 'QmA' }
         },
         protocol: null,
-        options: { useFSM: true, priority: 1 },
+        options: { useFSM: true, priority: PRIORITY_LOW },
         callback: (err) => {
           expect(err.code).to.eql('DIAL_ABORTED')
           done()
@@ -97,7 +98,7 @@ describe('dialer', () => {
           isConnected: () => null
         },
         protocol: '/echo/1.0.0',
-        options: { useFSM: true, priority: 0 },
+        options: { useFSM: true, priority: PRIORITY_HIGH },
         callback: () => {}
       }
 
@@ -121,7 +122,7 @@ describe('dialer', () => {
           isConnected: () => null
         },
         protocol: null,
-        options: { useFSM: true, priority: 1 },
+        options: { useFSM: true, priority: PRIORITY_LOW },
         callback: () => {}
       }
 
@@ -142,7 +143,7 @@ describe('dialer', () => {
           isConnected: () => null
         },
         protocol: null,
-        options: { useFSM: true, priority: 1 },
+        options: { useFSM: true, priority: PRIORITY_LOW },
         callback: (err) => {
           expect(runSpy.called).to.eql(false)
           expect(hasSpy.called).to.eql(true)

--- a/test/dialer.spec.js
+++ b/test/dialer.spec.js
@@ -18,17 +18,39 @@ const createInfos = utils.createInfos
 
 describe('dialer', () => {
   let switchA
+  let switchB
 
-  before((done) => createInfos(1, (err, infos) => {
+  before((done) => createInfos(2, (err, infos) => {
     expect(err).to.not.exist()
 
     switchA = new Switch(infos[0], new PeerBook())
+    switchB = new Switch(infos[1], new PeerBook())
 
     done()
   }))
 
   afterEach(() => {
     sinon.restore()
+  })
+
+  describe('connect', () => {
+    afterEach(() => {
+      switchA.dialer.clearBlacklist(switchB._peerInfo)
+    })
+
+    it('should use default options', (done) => {
+      switchA.dialer.connect(switchB._peerInfo, (err) => {
+        expect(err).to.exist()
+        done()
+      })
+    })
+
+    it('should be able to use custom options', (done) => {
+      switchA.dialer.connect(switchB._peerInfo, { useFSM: true, priority: 0 }, (err) => {
+        expect(err).to.exist()
+        done()
+      })
+    })
   })
 
   describe('queue', () => {

--- a/test/dialer.spec.js
+++ b/test/dialer.spec.js
@@ -58,7 +58,7 @@ describe('dialer', () => {
           id: { toB58String: () => 'QmA' }
         },
         protocol: null,
-        useFSM: true,
+        options: { useFSM: true, priority: 1 },
         callback: (err) => {
           expect(err.code).to.eql('DIAL_ABORTED')
           done()
@@ -75,7 +75,7 @@ describe('dialer', () => {
           isConnected: () => null
         },
         protocol: '/echo/1.0.0',
-        useFSM: true,
+        options: { useFSM: true, priority: 0 },
         callback: () => {}
       }
 
@@ -99,7 +99,7 @@ describe('dialer', () => {
           isConnected: () => null
         },
         protocol: null,
-        useFSM: true,
+        options: { useFSM: true, priority: 1 },
         callback: () => {}
       }
 
@@ -120,7 +120,7 @@ describe('dialer', () => {
           isConnected: () => null
         },
         protocol: null,
-        useFSM: true,
+        options: { useFSM: true, priority: 1 },
         callback: (err) => {
           expect(runSpy.called).to.eql(false)
           expect(hasSpy.called).to.eql(true)


### PR DESCRIPTION
This adds basic support for priorities. Currently, all priority 0 (highest) items will be run through the main dial queue and all priorities >= 1 will go through the cold call queue. This enables the proposed auto dial feature in libp2p, https://github.com/libp2p/js-libp2p/pull/349, to create low priority dials on peer discovery.

Since some applications may dial to peers without specifying a protocol, such as dialing to a content provider discovered through the DHT, only detecting the presence of a protocol is not sufficient to determine priority. `switch.dialer.connect` creates a direct path for applications to use the cold call queue. 

required by https://github.com/libp2p/js-libp2p/pull/349