### PR TITLE
fix: create separate events for connection tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,17 @@ Emitted when the switch encounters an error.
 
 ### `switch.on('peer-mux-closed', (peer) => {})`
 
-- `peer`: is instance of [PeerInfo][] that has info of the peer we have just closed a muxed connection.
+- `peer`: is instance of [PeerInfo][] that has info of the peer we have just closed a muxed connection with.
+
+### `switch.on('connection:start', (peer) => {})`
+This will be triggered anytime a new connection, regardless of state, is added to the switches internal connection tracking.
+
+- `peer`: is instance of [PeerInfo][] that has info of the peer we have just started a connection with.
+
+### `switch.on('connection:end', (peer) => {})`
+This will be triggered anytime an existing connection, regardless of state, is removed from the switches internal connection tracking.
+
+- `peer`: is instance of [PeerInfo][] that has info of the peer we have just closed a connection with.
 
 ### `switch.on('start', () => {})`
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ This will be triggered anytime a new connection, regardless of state, is added t
 - `peer`: is instance of [PeerInfo][] that has info of the peer we have just started a connection with.
 
 ### `switch.on('connection:end', (peer) => {})`
-This will be triggered anytime an existing connection, regardless of state, is removed from the switches internal connection tracking.
+This will be triggered anytime an existing connection, regardless of state, is removed from the switch's internal connection tracking.
 
 - `peer`: is instance of [PeerInfo][] that has info of the peer we have just closed a connection with.
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Emitted when the switch encounters an error.
 - `peer`: is instance of [PeerInfo][] that has info of the peer we have just closed a muxed connection with.
 
 ### `switch.on('connection:start', (peer) => {})`
-This will be triggered anytime a new connection, regardless of state, is added to the switches internal connection tracking.
+This will be triggered anytime a new connection is created.
 
 - `peer`: is instance of [PeerInfo][] that has info of the peer we have just started a connection with.
 

--- a/src/connection/base.js
+++ b/src/connection/base.js
@@ -80,6 +80,7 @@ class BaseConnection extends EventEmitter {
    * @returns {void}
    */
   _onDisconnected () {
+    this.switch.connection.remove(this)
     this.log('disconnected from %s', this.theirB58Id)
     this.emit('close')
     this.removeAllListeners()

--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -269,8 +269,6 @@ class ConnectionFSM extends BaseConnection {
   _onDisconnecting () {
     this.log('disconnecting from %s', this.theirB58Id, Boolean(this.muxer))
 
-    this.switch.connection.remove(this)
-
     delete this.switch.conns[this.theirB58Id]
 
     let tasks = []

--- a/src/connection/manager.js
+++ b/src/connection/manager.js
@@ -34,7 +34,11 @@ class ConnectionManager {
     if (!this.get(connection)) {
       this.connections[connection.theirB58Id].push(connection)
       this.switch.emit('connection:start', connection.theirPeerInfo)
-      connection.once('muxed', () => this.switch.emit('peer-mux-established', connection.theirPeerInfo))
+      if (connection.getState() === 'MUXED') {
+        this.switch.emit('peer-mux-established', connection.theirPeerInfo)
+      } else {
+        connection.once('muxed', () => this.switch.emit('peer-mux-established', connection.theirPeerInfo))
+      }
     }
   }
 
@@ -82,8 +86,10 @@ class ConnectionManager {
   remove (connection) {
     // No record of the peer, disconnect it
     if (!this.connections[connection.theirB58Id]) {
-      connection.theirPeerInfo.disconnect()
-      this.switch.emit('peer-mux-closed', connection.theirPeerInfo)
+      if (connection.theirPeerInfo) {
+        connection.theirPeerInfo.disconnect()
+        this.switch.emit('peer-mux-closed', connection.theirPeerInfo)
+      }
       return
     }
 

--- a/src/connection/manager.js
+++ b/src/connection/manager.js
@@ -33,7 +33,8 @@ class ConnectionManager {
     // Only add it if it's not there
     if (!this.get(connection)) {
       this.connections[connection.theirB58Id].push(connection)
-      this.switch.emit('peer-mux-established', connection.theirPeerInfo)
+      this.switch.emit('connection:start', connection.theirPeerInfo)
+      connection.once('muxed', () => this.switch.emit('peer-mux-established', connection.theirPeerInfo))
     }
   }
 
@@ -99,6 +100,9 @@ class ConnectionManager {
       connection.theirPeerInfo.disconnect()
       this.switch.emit('peer-mux-closed', connection.theirPeerInfo)
     }
+
+    // A tracked connection was closed, let the world know
+    this.switch.emit('connection:end', connection.theirPeerInfo)
   }
 
   /**


### PR DESCRIPTION
The `peer-mux-*` events are currently used for both connection tracking and muxed connection tracking. This creates a problem for the Connection Manager because it won't be able to track unmuxed connections. 

The Connection Manager should be aware of **all** connections that are created and closed. This adds events for libp2p and subsequently the Connection Manager to hook into.