### PR TITLE
fix: dont compare empty strings

### DIFF
--- a/src/transport.js
+++ b/src/transport.js
@@ -236,6 +236,7 @@ function ourAddresses (peerInfo) {
         : `${addr}/ipfs/${ourPeerId}`
       return ourAddrs.concat([addr, otherAddr])
     }, [])
+    .filter(a => Boolean(a))
     .concat(`/ipfs/${ourPeerId}`)
 }
 

--- a/test/transport-manager.spec.js
+++ b/test/transport-manager.spec.js
@@ -95,6 +95,23 @@ describe('Transport Manager', () => {
       expect(dialableAddrs[0].toString()).to.equal('/ip6/::1/tcp/4001')
     })
 
+    it('should filter out our addrs that start with /ipfs/', () => {
+      const queryAddrs = [
+        '/ip4/127.0.0.1/tcp/4002/ipfs/QmebzNV1kSzLfaYpSZdShuiABNUxoKT1vJmCdxM2iWsM2j'
+      ].map(a => Multiaddr(a))
+
+      const ourAddrs = [
+        '/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z'
+      ]
+
+      ourAddrs.forEach(a => peerInfo.multiaddrs.add(a))
+
+      const dialableAddrs = TransportManager.dialables(dialAllTransport, queryAddrs, peerInfo)
+
+      expect(dialableAddrs).to.have.length(1)
+      expect(dialableAddrs[0]).to.eql(queryAddrs[0])
+    })
+
     it('should filter our addresses over relay/rendezvous', () => {
       const peerId = peerInfo.id.toB58String()
       const queryAddrs = [


### PR DESCRIPTION
Currently there is something in the libp2p system that ends up adding `/ipfs/{peerId}` to our PeerInfo address list. This shouldn't be happening. While this doesn't solve that issue (I'm still determining where that's happening), it fixes an issue with transport address filtering. If any item in the list of `ourAddrs` happens to be an empty string, that will cause **all** the target peers addresses to get filtered out. This avoids that by filtering out empty strings from `ourAddrs`