### PR TITLE
fix: resolve transport sort order in browsers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -127,9 +127,11 @@ class Switch extends EventEmitter {
 
     // Only listen on transports we actually have addresses for
     return myTransports.filter((ts) => this.transports[ts].filter(myAddrs).length > 0)
-      // push Circuit to be the last proto to be dialed
-      .sort((a) => {
-        return a === Circuit.tag ? 1 : -1
+      // push Circuit to be the last proto to be dialed, and alphabetize the others
+      .sort((a, b) => {
+        if (a === Circuit.tag) return 1
+        if (b === Circuit.tag) return -1
+        return a < b ? -1 : 1
       })
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,7 @@ class Switch extends EventEmitter {
     return myTransports.filter((ts) => this.transports[ts].filter(myAddrs).length > 0)
       // push Circuit to be the last proto to be dialed
       .sort((a) => {
-        return a === Circuit.tag ? 1 : 0
+        return a === Circuit.tag ? 1 : -1
       })
   }
 

--- a/test/switch.spec.js
+++ b/test/switch.spec.js
@@ -27,7 +27,11 @@ describe('Switch', () => {
         WebSocketStar: transport
       }
 
-      expect(switchA.availableTransports(mockPeerInfo)[2]).to.eql('Circuit')
+      expect(switchA.availableTransports(mockPeerInfo)).to.eql([
+        'TCP',
+        'WebSocketStar',
+        'Circuit'
+      ])
     })
   })
 })

--- a/test/switch.spec.js
+++ b/test/switch.spec.js
@@ -1,0 +1,33 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+
+const Switch = require('../src')
+
+describe('Switch', () => {
+  describe('.availableTransports', () => {
+    it('should always sort circuit last', () => {
+      const switchA = new Switch({}, {})
+      const transport = {
+        filter: (addrs) => addrs
+      }
+      const mockPeerInfo = {
+        multiaddrs: {
+          toArray: () => ['a', 'b', 'c']
+        }
+      }
+
+      switchA.transports = {
+        Circuit: transport,
+        TCP: transport,
+        WebSocketStar: transport
+      }
+
+      expect(switchA.availableTransports(mockPeerInfo)[2]).to.eql('Circuit')
+    })
+  })
+})


### PR DESCRIPTION
This fixes an issue with how browsers handle sorting. In Chrome, the existing code would always sort Circuit last. In Firefox, it does not. The existing logic doesn't take any consideration into the `b` argument of sort. The problem with this is you will get unreliable behavior because the `a` and `b` values are sorted as "equal" if `a` is not `"Circuit"`.

This PR changes the logic to always prioritize `a` if it is not `"Circuit"`, and if it is, de-prioritize it. 

The caveat of this brief sort logic is that the other transports will have different orders in different browsers. This doesn't matter to Switch, it only cares that Circuit is last. This is why the test is set to only validate that part of the order.

required by https://github.com/ipfs/interop/issues/63