### PR TITLE
fix: dont use peerinfo distinct

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -49,17 +49,17 @@ module.exports.identifyDialer = (connection, cryptoPeerInfo) => {
 }
 
 /**
- * Copied from `unique-by`, https://github.com/mlmorg/unique-by.
+ * Copied (and modified) from `unique-by`, https://github.com/mlmorg/unique-by.
  * @param {Array} arr The array to get unique values for
  * @param {function(value)} getValue The function to determine what is compared
  * @returns {Array}
  */
-module.exports.uniqueBy = function (arr, getValue) {
-  var unique = []
-  var found = {}
+module.exports.uniqueBy = (arr, getValue) => {
+  let unique = []
+  let found = {}
 
-  arr.forEach(function addUniques (obj) {
-    var value = getValue(obj)
+  arr.forEach((obj) => {
+    const value = getValue(obj)
     if (!found[value]) {
       found[value] = true
       unique.push(obj)

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,13 +58,6 @@ module.exports.uniqueBy = function (arr, getValue) {
   var unique = []
   var found = {}
 
-  if (typeof getValue !== 'function') {
-    var key = getValue
-    getValue = function defaultGetValue (obj) {
-      return obj[key]
-    }
-  }
-
   arr.forEach(function addUniques (obj) {
     var value = getValue(obj)
     if (!found[value]) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,22 +49,12 @@ module.exports.identifyDialer = (connection, cryptoPeerInfo) => {
 }
 
 /**
- * Copied (and modified) from `unique-by`, https://github.com/mlmorg/unique-by.
+ * Get unique values from `arr` using `getValue` to determine
+ * what is used for uniqueness
  * @param {Array} arr The array to get unique values for
  * @param {function(value)} getValue The function to determine what is compared
  * @returns {Array}
  */
 module.exports.uniqueBy = (arr, getValue) => {
-  let unique = []
-  let found = {}
-
-  arr.forEach((obj) => {
-    const value = getValue(obj)
-    if (!found[value]) {
-      found[value] = true
-      unique.push(obj)
-    }
-  })
-
-  return unique
+  return [...new Map(arr.map((i) => [getValue(i), i])).values()]
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,3 +47,31 @@ module.exports.identifyDialer = (connection, cryptoPeerInfo) => {
     })
   })
 }
+
+/**
+ * Copied from `unique-by`, https://github.com/mlmorg/unique-by.
+ * @param {Array} arr The array to get unique values for
+ * @param {function(value)} getValue The function to determine what is compared
+ * @returns {Array}
+ */
+module.exports.uniqueBy = function (arr, getValue) {
+  var unique = []
+  var found = {}
+
+  if (typeof getValue !== 'function') {
+    var key = getValue
+    getValue = function defaultGetValue (obj) {
+      return obj[key]
+    }
+  }
+
+  arr.forEach(function addUniques (obj) {
+    var value = getValue(obj)
+    if (!found[value]) {
+      found[value] = true
+      unique.push(obj)
+    }
+  })
+
+  return unique
+}


### PR DESCRIPTION
replaces https://github.com/libp2p/js-peer-info/pull/78

This is a workaround, as noted in the code comments, until https://github.com/libp2p/interface-transport/issues/41 is completed and we can allow transports to do their own unique filtering.

This removes our dependency on the `PeerInfo.multiaddrs.distinct()` method, which is a patch for this same issue. This attempts to improve on the logic there by being more specific about port uniqueness, which should also allow us to implement multiple port 0 listens, https://github.com/libp2p/js-libp2p-switch/pull/227.