### PR TITLE
stats - stat - prevent 0ms timeDiff breaking movingAverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ jobs:
 
     - stage: check
       script:
-        - npx aegir commitlint --travis
         - npx aegir dep-check
         - npm run lint
 

--- a/src/stats/stat.js
+++ b/src/stats/stat.js
@@ -182,7 +182,9 @@ class Stats extends EventEmitter {
   _updateFrequencyFor (key, timeDiffMS, latestTime) {
     const count = this._frequencyAccumulators[key] || 0
     this._frequencyAccumulators[key] = 0
-    const hz = (count / timeDiffMS) * 1000
+    // if `timeDiff` is zero, `hz` becomes Infinity, so we fallback to 1ms
+    const safeTimeDiff = timeDiffMS || 1
+    const hz = (count / safeTimeDiff) * 1000
 
     let movingAverages = this._movingAverages[key]
     if (!movingAverages) {


### PR DESCRIPTION
Fixes https://github.com/libp2p/js-libp2p-switch/issues/335

This is a work around, and will still cause an inaccurate movingAverage when pushing in data immediately after creation, but movingAverage will "heal"  over time

a more correct solution might be not pushing in the initial zero and first waiting for 2 samples