### PR TITLE
fix: dont blindly add observed addresses to our list

### DIFF
--- a/src/connection/manager.js
+++ b/src/connection/manager.js
@@ -179,12 +179,7 @@ class ConnectionManager {
               })
             }
 
-            const { peerInfo, observedAddrs } = results
-
-            for (var i = 0; i < observedAddrs.length; i++) {
-              var addr = observedAddrs[i]
-              this.switch._peerInfo.multiaddrs.addSafe(addr)
-            }
+            const { peerInfo } = results
 
             if (peerInfo) {
               conn.setPeerInfo(peerInfo)


### PR DESCRIPTION
Until we can properly validate the observed address our peer tells us about, we shouldn't blindly add it to our address list. Until we have better NAT management we cant reliably validate that we're adding an appropriate address for ourselves.

This is a "good citizen" fix. Since we will advertise these addresses to new peers, we should do our due diligence to make sure they're reasonably accurate.